### PR TITLE
setup_dependencies: add link to Netronome's bpftool .deb package

### DIFF
--- a/setup_dependencies.org
+++ b/setup_dependencies.org
@@ -123,4 +123,11 @@ On a machine running the Fedora Linux distribution, install package:
 
 ** Packages on Debian/Ubuntu
 
-Unfortunately, bpftool is not currently packaged for Debian/Ubuntu.
+Unfortunately, bpftool is not officially packaged for Debian/Ubuntu
+[[https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896165)][yet]].
+
+However, note that an unofficial
+[[https://help.netronome.com/helpdesk/attachments/36025601060][.deb package]]
+is provided by Netronome
+[[https://help.netronome.com/support/solutions/articles/36000050009-agilio-ebpf-2-0-6-extended-berkeley-packet-filter][on their support website]].
+The binary is statically linked, and should work on any x86-64 Linux machine.


### PR DESCRIPTION
bpftool is not packaged for Debian/Ubuntu at this time. However, Netronome provides a .deb package for it (statically linked executable), which might help people willing to try the tool without downloading the kernel tree to build it. Let's add the link to that package in the documentation (this should be removed when bpftool gets proper packaging in Debian).

Follow-up on the comments in #17.