### PR TITLE
Generalize xdp_stats from packet04

### DIFF
--- a/basic04-pinning-maps/xdp_prog_kern.c
+++ b/basic04-pinning-maps/xdp_prog_kern.c
@@ -23,7 +23,7 @@ struct bpf_map_def SEC("maps") xdp_stats_map = {
 #endif
 
 static __always_inline
-__u32 record_xdp_stats_action(struct xdp_md *ctx, __u32 action)
+__u32 xdp_stats_record_action(struct xdp_md *ctx, __u32 action)
 {
 	void *data_end = (void *)(long)ctx->data_end;
 	void *data     = (void *)(long)ctx->data;
@@ -54,7 +54,7 @@ int  xdp_pass_func(struct xdp_md *ctx)
 {
 	__u32 action = XDP_PASS; /* XDP_PASS = 2 */
 
-	return record_xdp_stats_action(ctx, action);
+	return xdp_stats_record_action(ctx, action);
 }
 
 SEC("xdp_drop")
@@ -62,7 +62,7 @@ int  xdp_drop_func(struct xdp_md *ctx)
 {
 	__u32 action = XDP_DROP;
 
-	return record_xdp_stats_action(ctx, action);
+	return xdp_stats_record_action(ctx, action);
 }
 
 SEC("xdp_abort")
@@ -70,7 +70,7 @@ int  xdp_abort_func(struct xdp_md *ctx)
 {
 	__u32 action = XDP_ABORTED;
 
-	return record_xdp_stats_action(ctx, action);
+	return xdp_stats_record_action(ctx, action);
 }
 
 char _license[] SEC("license") = "GPL";

--- a/common/common.mk
+++ b/common/common.mk
@@ -23,7 +23,7 @@ USER_OBJ := ${USER_C:.c=.o}
 COMMON_DIR ?= ../common/
 
 COPY_LOADER ?=
-LOADER_DIR := $(COMMON_DIR)/../basic04-pinning-maps
+LOADER_DIR ?= $(COMMON_DIR)/../basic04-pinning-maps
 
 OBJECT_LIBBPF = $(LIBBPF_DIR)/libbpf.a
 
@@ -44,14 +44,14 @@ LDFLAGS ?= -L$(LIBBPF_DIR)
 
 LIBS = -lbpf -lelf
 
-all: llvm-check $(USER_TARGETS) $(XDP_OBJ) $(COPY_LOADER)
+all: llvm-check $(USER_TARGETS) $(XDP_OBJ) $(COPY_LOADER) $(COPY_STATS)
 
 .PHONY: clean $(CLANG) $(LLC)
 
 clean:
 	$(MAKE) -C $(LIBBPF_DIR) clean
 	$(MAKE) -C $(COMMON_DIR) clean
-	rm -f $(USER_TARGETS) $(XDP_OBJ) $(USER_OBJ) $(COPY_LOADER)
+	rm -f $(USER_TARGETS) $(XDP_OBJ) $(USER_OBJ) $(COPY_LOADER) $(COPY_STATS)
 	rm -f *.ll
 	rm -f *~
 
@@ -59,6 +59,12 @@ ifdef COPY_LOADER
 $(COPY_LOADER): $(LOADER_DIR)/${COPY_LOADER:=.c} $(COMMON_H)
 	make -C $(LOADER_DIR) $(COPY_LOADER)
 	cp $(LOADER_DIR)/$(COPY_LOADER) $(COPY_LOADER)
+endif
+
+ifdef COPY_STATS
+$(COPY_STATS): $(LOADER_DIR)/${COPY_STATS:=.c} $(COMMON_H)
+	make -C $(LOADER_DIR) $(COPY_STATS)
+	cp $(LOADER_DIR)/$(COPY_STATS) $(COPY_STATS)
 endif
 
 # For build dependency on this file, if it gets updated

--- a/common/common.mk
+++ b/common/common.mk
@@ -65,6 +65,8 @@ ifdef COPY_STATS
 $(COPY_STATS): $(LOADER_DIR)/${COPY_STATS:=.c} $(COMMON_H)
 	make -C $(LOADER_DIR) $(COPY_STATS)
 	cp $(LOADER_DIR)/$(COPY_STATS) $(COPY_STATS)
+# Needing xdp_stats imply depending on header files:
+EXTRA_DEPS := $(COMMON_DIR)/xdp_stats_kern.h $(COMMON_DIR)/xdp_stats_kern_user.h
 endif
 
 # For build dependency on this file, if it gets updated

--- a/common/xdp_stats_kern.h
+++ b/common/xdp_stats_kern.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+/* Used *ONLY* by BPF-prog running kernel side. */
+#ifndef __XDP_STATS_KERN_H
+#define __XDP_STATS_KERN_H
+
+/* Data record type 'struct datarec' is defined in common/xdp_stats_kern_user.h,
+ * programs using this header must first include that file.
+ */
+#ifndef __XDP_STATS_KERN_USER_H
+#warning "You forgot to #include <../common/xdp_stats_kern_user.h>"
+#include <../common/xdp_stats_kern_user.h>
+#endif
+
+/* Keeps stats per (enum) xdp_action */
+struct bpf_map_def SEC("maps") xdp_stats_map = {
+	.type        = BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size    = sizeof(__u32),
+	.value_size  = sizeof(struct datarec),
+	.max_entries = XDP_ACTION_MAX,
+};
+
+static __always_inline
+__u32 xdp_stats_record_action(struct xdp_md *ctx, __u32 action)
+{
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data     = (void *)(long)ctx->data;
+
+	if (action >= XDP_ACTION_MAX)
+		return XDP_ABORTED;
+
+	/* Lookup in kernel BPF-side return pointer to actual data record */
+	struct datarec *rec = bpf_map_lookup_elem(&xdp_stats_map, &action);
+	if (!rec)
+		return XDP_ABORTED;
+
+	/* Calculate packet length */
+	__u64 bytes = data_end - data;
+
+	/* BPF_MAP_TYPE_PERCPU_ARRAY returns a data record specific to current
+	 * CPU and XDP hooks runs under Softirq, which makes it safe to update
+	 * without atomic operations.
+	 */
+	rec->rx_packets++;
+	rec->rx_bytes += bytes;
+
+	return action;
+}
+
+#endif /* __XDP_STATS_KERN_H */

--- a/common/xdp_stats_kern_user.h
+++ b/common/xdp_stats_kern_user.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+/* Used by BPF-prog kernel side BPF-progs and userspace programs,
+ * for sharing xdp_stats common struct and DEFINEs.
+ */
+#ifndef __XDP_STATS_KERN_USER_H
+#define __XDP_STATS_KERN_USER_H
+
+/* This is the data record stored in the map */
+struct datarec {
+	__u64 rx_packets;
+	__u64 rx_bytes;
+};
+
+#ifndef XDP_ACTION_MAX
+#define XDP_ACTION_MAX (XDP_REDIRECT + 1)
+#endif
+
+#endif /* __XDP_STATS_KERN_USER_H */

--- a/packet01-parsing/Makefile
+++ b/packet01-parsing/Makefile
@@ -7,5 +7,6 @@ LIBBPF_DIR = ../libbpf/src/
 COMMON_DIR = ../common
 
 COPY_LOADER := xdp_loader
+COPY_STATS  := xdp_stats
 
 include $(COMMON_DIR)/common.mk

--- a/packet02-rewriting/Makefile
+++ b/packet02-rewriting/Makefile
@@ -7,6 +7,7 @@ LIBBPF_DIR = ../libbpf/src/
 COMMON_DIR = ../common
 
 COPY_LOADER := xdp_loader
+COPY_STATS  := xdp_stats
 EXTRA_DEPS := $(COMMON_DIR)/parsing_helpers.h
 
 include $(COMMON_DIR)/common.mk

--- a/packet02-rewriting/xdp_prog_kern.c
+++ b/packet02-rewriting/xdp_prog_kern.c
@@ -99,7 +99,7 @@ int  xdp_parser_func(struct xdp_md *ctx)
 	 * we don't want to deal with, we just pass up the stack and let the
 	 * kernel deal with it.
 	 */
-        __u32 action = XDP_PASS; /* Default action */
+	__u32 action = XDP_PASS; /* Default action */
 
         /* These keep track of the next header type and iterator pointer */
 	struct hdr_cursor nh;

--- a/packet02-rewriting/xdp_prog_kern.c
+++ b/packet02-rewriting/xdp_prog_kern.c
@@ -7,6 +7,10 @@
 // The parsing helper functions from the packet01 lesson have moved here
 #include "../common/parsing_helpers.h"
 
+/* Defines xdp_stats_map */
+#include "../common/xdp_stats_kern_user.h"
+#include "../common/xdp_stats_kern.h"
+
 /* Pops the outermost VLAN tag off the packet. Returns the popped VLAN ID on
  * success or -1 on failure.
  */
@@ -141,7 +145,7 @@ int  xdp_parser_func(struct xdp_md *ctx)
                         action = XDP_DROP;
         }
 out:
-	return action;
+	return xdp_stats_record_action(ctx, action);
 }
 
 char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
This ties together basic04 with packet01 (and packet02's solution to packet01).

The map that is used for xdp_stats are made easy avail to BPF-progs via two include files in common/
for adding XDP stats to programs.

The testenv.sh gets a new 'stats' command.
The common.mk Makefile system gets a COPY_STATS option like COPY_LOADER.

This allows participants to see their XDP_DROP packets in form of a xdp_stats counter.
