### PR TITLE
Initial steps for an advanced AF_XDP assignment

### DIFF
--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -9,9 +9,7 @@ facility. XDP is an *in-kernel* fast-path, that operates on raw-frames
 To support fast delivery of /raw-frames into userspace/, XDP can *bypass*
 the Linux Kernel network stack via XDP_REDIRECT'ing into a special BPF-map
 containing AF_XDP sockets. The AF_XDP socket is an new Address Family type.
-
-The kernel documentation for AF_XDP:
-- https://www.kernel.org/doc/html/latest/networking/af_xdp.html
+([[https://www.kernel.org/doc/html/latest/networking/af_xdp.html][The kernel documentation for AF_XDP]]).
 
 * Lessons
 

--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -1,0 +1,15 @@
+# -*- fill-column: 76; -*-
+#+TITLE: Advanced: XDP userspace delivery via AF_XDP
+#+OPTIONS: ^:nil
+
+It is important to understand that XDP in-itself is not a kernel bypass
+facility. XDP is an *in-kernel* fast-path, that operates on raw-frames
+"inline" before they reach the normal Linux Kernel network stack.
+
+To support fast delivery of /raw-frames into userspace/, XDP can *bypass*
+the Linux Kernel network stack via XDP_REDIRECT'ing into a special BPF-map
+containing AF_XDP sockets. The AF_XDP socket is an new Address Family type.
+
+The kernel documentation for AF_XDP:
+- https://www.kernel.org/doc/html/latest/networking/af_xdp.html
+

--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -27,16 +27,33 @@ driver RX-queue into an (AF_XDP) socket.
 The basic queues used by AF_XDP are Single-Producer/Single-Consumer (SPSC)
 descriptor ring queues:
 
-- The *Single*-/Producer/ (SP) bind to specific RX-*/queue id/*, and
+- The *Single*-/Producer/ (SP) bind to specific RX-*queue id*, and
   NAPI-softirq assures only 1-CPU process 1-RX-queue id (per scheduler
   interval).
 
-- The *Single*-/Consumer/ (SC) is one-application, with a (bounded) buffer
-  pool (UMEM) allocated by userspace (register with kernel). Reading
-  descriptors from a ring, that point into UMEM. /No memory allocation/, but
-  return frames to UMEM in timely manner.
+- The *Single*-/Consumer/ (SC) is one-application, reading descriptors from
+  a ring, that point into UMEM area.
+
+There are *no memory allocation* per packet. Instead the UMEM memory area
+used for packets is pre-allocated and there by bounded. The UMEM area
+consists of a number of equally sized chunks, that userspace have registered
+with the kernel (via XDP_UMEM_REG setsockopt system call). *Importantly*:
+This also means that you are responsible for returning frames to UMEM in
+timely manner, and pre-allocated enough for your application usage pattern.
 
 The [[http://www.lemis.com/grog/Documentation/vj/lca06vj.pdf][transport signature]] that Van Jacobson talked about, are replaced by the
 XDP/eBPF program choosing which AF_XDP socket to XDP_REDIRECT into.
+
+** Details: Actually four SPSC ring queues
+
+As explained in the [[ https://www.kernel.org/doc/html/latest/networking/af_xdp.html][AF_XDP kernel doc]] there are actually 4 SPSC ring queues.
+
+In summary: the AF_XDP /socket/ has two rings for *RX* and *TX*, which
+contain descriptors that points into UMEM area. The UMEM area has two rings:
+*FILL* ring and *COMPLETION* ring. In the *FILL* ring: the application gives
+the kernel a packet area to *RX* fill. In the *COMPLETION* ring, the kernel
+tells the application that *TX is done* for a packet area (which then can be
+reused). This scheme is for transferring ownership of UMEM packet areas
+between the kernel and the userspace application.
 
 

--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -78,6 +78,25 @@ Alternative work-arounds:
 2. For testing purposes reduce RXQ number to 1,
    e.g. via command =ethtool -L <interface> combined 1=
 
+** Driver support and zero-copy mode
+
+As hinted in the intro (driver level) support for AF_XDP depend on drivers
+implementing the XDP_REDIRECT action. For all driver implementing the basic
+XDP_REDIRECT action, AF_XDP in "copy-mode" is supported. The "copy-mode" is
+surprisingly fast, and does a single-copy of the frame (including any XDP
+placed meta-data) into the UMEM area. The userspace API remains the same.
+
+For AF_XDP "zero-copy" support the driver need to implement and expose the
+API for registering and using the UMEM area directly in the NIC RX-ring
+structure for DMA delivery.
+
+Depending on your use-case, it can still make sense to use the "copy-mode"
+on a "zero-copy" capable driver. If for some-reason, not all traffic on a
+RX-queue is for the AF_XDP socket, and the XDP program multiplex between
+XDP_REDIRECT and XDP_PASS, then "copy-mode" can be relevant. As in
+"zero-copy" mode doing XDP_PASS have a fairly high cost, which involves
+allocating memory and copying over the frame.
+
 * Missing elements
 
 *Lesson incomplete*

--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -78,3 +78,14 @@ Alternative work-arounds:
 2. For testing purposes reduce RXQ number to 1,
    e.g. via command =ethtool -L <interface> combined 1=
 
+* Missing elements
+
+*Lesson incomplete*
+
+This lesson is missing some assignments, but first we need to provide an
+AF_XDP sample program. The sample should use the libbpf API for AF_XDP
+sockets. It also need to include an actual XDP bpf program that is more
+robust, and demonstrate how to read the RXQ-info about the RX-queue number,
+and only redirect if the RX-queue id match, and maybe give stats on redirect
+vs. XDP_PASS (not matching RX-queue id) packets.
+

--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -89,3 +89,6 @@ robust, and demonstrate how to read the RXQ-info about the RX-queue number,
 and only redirect if the RX-queue id match, and maybe give stats on redirect
 vs. XDP_PASS (not matching RX-queue id) packets.
 
+Note: One of the reasons for providing a BPF C-code example is that the
+kernel removed =samples/bpf/xdpsock_kern.c=, when libbpf was extended with
+static BPF-instructions for AF_XDP redirect.

--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -56,4 +56,25 @@ tells the application that *TX is done* for a packet area (which then can be
 reused). This scheme is for transferring ownership of UMEM packet areas
 between the kernel and the userspace application.
 
+** Gotcha by RX-queue id binding
+
+The most common mistake: Why am I not seeing any traffic on the AF_XDP
+socket?
+
+As you just learned from above, the AF_XDP socket bound to a *single
+RX-queue id* (for performance reasons). Thus, your userspace program is only
+receiving raw-frames from a specific RX-queue id number. NICs will by
+default spread flows with RSS-hashing over all available RX-queues. Thus,
+traffic likely not hitting queue you expect.
+
+You *MUST* configure NIC *HW filters* to /steer to RX-queue id/. This can be
+configured by use of ethtool or TC HW offloading filter setup.
+
+TODO: This lesson should contain some examples on howto use ethtool.
+
+Alternative work-arounds:
+1. Create as many AF_XDP sockets as RXQs, and have userspace poll()/select
+   on all sockets.
+2. For testing purposes reduce RXQ number to 1,
+   e.g. via command =ethtool -L <interface> combined 1=
 

--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -25,11 +25,11 @@ driver RX-queue into an (AF_XDP) socket.
 The basic queues used by AF_XDP are Single-Producer/Single-Consumer (SPSC)
 descriptor ring queues:
 
-- The *Single*-/Producer/ (SP) bind to specific RX-*queue id*, and
+- The *Single-Producer* (SP) bind to specific RX *queue id*, and
   NAPI-softirq assures only 1-CPU process 1-RX-queue id (per scheduler
   interval).
 
-- The *Single*-/Consumer/ (SC) is one-application, reading descriptors from
+- The *Single-Consumer* (SC) is one-application, reading descriptors from
   a ring, that point into UMEM area.
 
 There are *no memory allocation* per packet. Instead the UMEM memory area

--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -13,3 +13,30 @@ containing AF_XDP sockets. The AF_XDP socket is an new Address Family type.
 The kernel documentation for AF_XDP:
 - https://www.kernel.org/doc/html/latest/networking/af_xdp.html
 
+* Lessons
+
+** Where does AF_XDP performance come from?
+
+The AF_XDP socket is really fast, but what the secret behind this
+performance boost?
+
+One of the basic ideas behind AF_XDP dates back to [[https://en.wikipedia.org/wiki/Van_Jacobson][Van Jacobson]]'s talk about
+[[https://lwn.net/Articles/169961/][network channels]]. It is about creating a Lock-free [[https://lwn.net/Articles/169961/][channel]] directly from
+driver RX-queue into an (AF_XDP) socket.
+
+The basic queues used by AF_XDP are Single-Producer/Single-Consumer (SPSC)
+descriptor ring queues:
+
+- The *Single*-/Producer/ (SP) bind to specific RX-*/queue id/*, and
+  NAPI-softirq assures only 1-CPU process 1-RX-queue id (per scheduler
+  interval).
+
+- The *Single*-/Consumer/ (SC) is one-application, with a (bounded) buffer
+  pool (UMEM) allocated by userspace (register with kernel). Reading
+  descriptors from a ring, that point into UMEM. /No memory allocation/, but
+  return frames to UMEM in timely manner.
+
+The [[http://www.lemis.com/grog/Documentation/vj/lca06vj.pdf][transport signature]] that Van Jacobson talked about, are replaced by the
+XDP/eBPF program choosing which AF_XDP socket to XDP_REDIRECT into.
+
+


### PR DESCRIPTION
Hi @chaudron 

I've created this initial README.org for framing an advanced AF_XDP assignment, that you can take over.

I/we still need to rebase libbpf git-submodule, to get the latest AF_XDP xsk.h headers, that @bjoto and @magnus-karlsson introduced.

One of the reasons for doing this is to providing a BPF C-code example, after the kernel removed samples/bpf/xdpsock_kern.c, to give people easier access to some code they can build upon/extend.
