### PR TITLE
fix up typo in code comments

### DIFF
--- a/packet01-parsing/xdp_prog_kern.c
+++ b/packet01-parsing/xdp_prog_kern.c
@@ -53,7 +53,7 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh,
 }*/
 
 /* Assignment 3: Implement and use this */
-/*static __always_inline int parse_icmp6hdr(struct hdr_cursor *nh,,
+/*static __always_inline int parse_icmp6hdr(struct hdr_cursor *nh,
 					  void *data_end,
 					  struct icmp6hdr **icmp6hdr)
 {


### PR DESCRIPTION
following the previous commit cacc999285ebce2eb705b04e8da9462a025dcb77
and fix its typo mistake
