### PR TITLE
Add tracing examples

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -38,7 +38,7 @@ EXTRA_DEPS +=
 # BPF-prog kern and userspace shares struct via header file:
 KERN_USER_H ?= $(wildcard common_kern_user.h)
 
-CFLAGS ?= -I$(LIBBPF_DIR)/root/usr/include/
+CFLAGS ?= -I$(LIBBPF_DIR)/root/usr/include/ -g
 CFLAGS += -I../headers/
 LDFLAGS ?= -L$(LIBBPF_DIR)
 

--- a/common/common.mk
+++ b/common/common.mk
@@ -42,7 +42,7 @@ CFLAGS ?= -I$(LIBBPF_DIR)/root/usr/include/ -g
 CFLAGS += -I../headers/
 LDFLAGS ?= -L$(LIBBPF_DIR)
 
-LIBS = -l:libbpf.a -lelf
+LIBS = -l:libbpf.a -lelf $(USER_LIBS)
 
 all: llvm-check $(USER_TARGETS) $(XDP_OBJ) $(COPY_LOADER) $(COPY_STATS)
 

--- a/common/common_defines.h
+++ b/common/common_defines.h
@@ -1,6 +1,10 @@
 #ifndef __COMMON_DEFINES_H
 #define __COMMON_DEFINES_H
 
+#include <net/if.h>
+#include <linux/types.h>
+#include <stdbool.h>
+
 struct config {
 	__u32 xdp_flags;
 	int ifindex;

--- a/common/common_user_bpf_xdp.c
+++ b/common/common_user_bpf_xdp.c
@@ -179,8 +179,9 @@ struct bpf_object *load_bpf_and_xdp_attach(struct config *cfg)
 	return bpf_obj;
 }
 
+#define XDP_UNKNOWN	XDP_REDIRECT + 1
 #ifndef XDP_ACTION_MAX
-#define XDP_ACTION_MAX (XDP_REDIRECT + 1)
+#define XDP_ACTION_MAX (XDP_UNKNOWN + 1)
 #endif
 
 static const char *xdp_action_names[XDP_ACTION_MAX] = {
@@ -189,6 +190,7 @@ static const char *xdp_action_names[XDP_ACTION_MAX] = {
 	[XDP_PASS]      = "XDP_PASS",
 	[XDP_TX]        = "XDP_TX",
 	[XDP_REDIRECT]  = "XDP_REDIRECT",
+	[XDP_UNKNOWN]	= "XDP_UNKNOWN",
 };
 
 const char *action2str(__u32 action)

--- a/headers/linux/err.h
+++ b/headers/linux/err.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
+#ifndef __LINUX_ERR_H
+#define __LINUX_ERR_H
+
+#include <linux/types.h>
+#include <asm/errno.h>
+
+#define MAX_ERRNO       4095
+
+#define IS_ERR_VALUE(x) ((x) >= (unsigned long)-MAX_ERRNO)
+
+static inline void * ERR_PTR(long error_)
+{
+	return (void *) error_;
+}
+
+static inline long PTR_ERR(const void *ptr)
+{
+	return (long) ptr;
+}
+
+static inline bool IS_ERR(const void *ptr)
+{
+	return IS_ERR_VALUE((unsigned long)ptr);
+}
+
+static inline bool IS_ERR_OR_NULL(const void *ptr)
+{
+	return (!ptr) || IS_ERR_VALUE((unsigned long)ptr);
+}
+
+#endif

--- a/tracing01-xdp-simple/Makefile
+++ b/tracing01-xdp-simple/Makefile
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+
+# Departing from the implicit _user.c scheme
+XDP_TARGETS  := trace_prog_kern xdp_prog_kern
+USER_TARGETS := trace_load_and_stats
+
+LIBBPF_DIR = ../libbpf/src/
+COMMON_DIR = ../common/
+
+include $(COMMON_DIR)/common.mk
+

--- a/tracing01-xdp-simple/README.org
+++ b/tracing01-xdp-simple/README.org
@@ -1,0 +1,205 @@
+# -*- fill-column: 76; -*-
+#+TITLE: Tutorial: Tracing01 - monitor xdp tracepoint
+#+OPTIONS: ^:nil
+
+In this lesson we will show how to create and load eBPF program that
+hooks on xdp:exception tracepoint and get its values to user space
+stats application.
+
+* Table of Contents                                                     :TOC:
+- [[#using-libbpf][XDP tracepoints]]
+  - [[#xdp-tracepoints][XDP tracepoints]]
+  - [[#tracepoint-program-section][Tracepoint program section]]
+  - [[#tracepoint-arguments][Tracepoint arguments]]
+  - [[#tracepoint-attaching][Tracepoint attaching]]
+  - [[#hash-map][HASH map]]
+- [[#assignments][Assignments]]
+  - [[#assignment-1][Assignment 1: Setting up your test lab]]
+  - [[#assignment-2][Assignment 2: Load tracepoint monitor program]]
+
+
+* XDP tracepoints
+
+The eBPF programs can be attached also to tracepoints. There are
+several tracepoints related to xdp:
+
+#+begin_example sh
+ls /sys/kernel/debug/tracing/events/xdp/
+xdp_cpumap_enqueue
+xdp_cpumap_kthread
+xdp_devmap_xmit
+xdp_exception
+xdp_redirect
+xdp_redirect_err
+xdp_redirect_map
+xdp_redirect_map_err
+#+end_example
+
+** Tracepoint program section
+
+The bpf library expects the tracepoint eBPF program to be stored
+in a section with following name:
+
+#+begin_example sh
+tracepoint/sys/tracepoint
+#+end_example
+
+where 'sys' is the tracepoint subsystem and 'tracepoint' is
+the tracepoint name.
+
+which can be done with following construct:
+
+#+begin_example sh
+SEC("tracepoint/xdp/xdp_exception")
+int trace_xdp_exception(struct xdp_exception_ctx *ctx)
+#+end_example
+
+** Tracepoint arguments
+
+There's single program pointer argument which points
+to the structure, that defines the tracepoint fields.
+
+Like for xdp:xdp_exception tracepoint:
+
+#+begin_example sh
+struct xdp_exception_ctx {
+        __u64 __pad;      // First 8 bytes are not accessible by bpf code
+        __s32 prog_id;    //      offset:8;  size:4; signed:1;
+        __u32 act;        //      offset:12; size:4; signed:0;
+        __s32 ifindex;    //      offset:16; size:4; signed:1;
+};
+
+int trace_xdp_exception(struct xdp_exception_ctx *ctx)
+#+end_example
+
+This struct is exported in tracepoint format file:
+
+#+begin_example sh
+# cat /sys/kernel/debug/tracing/events/xdp/xdp_exception/format
+...
+        field:unsigned short common_type;       offset:0;       size:2; signed:0;
+        field:unsigned char common_flags;       offset:2;       size:1; signed:0;
+        field:unsigned char common_preempt_count;       offset:3;       size:1; signed:0;
+        field:int common_pid;   offset:4;       size:4; signed:1;
+
+        field:int prog_id;      offset:8;       size:4; signed:1;
+        field:u32 act;  offset:12;      size:4; signed:0;
+        field:int ifindex;      offset:16;      size:4; signed:1;
+...
+#+end_example
+
+** Tracepoint attaching
+
+To load a tracepoint program for this example we use following bpf
+library helper function:
+
+#+begin_example sh
+bpf_prog_load(cfg->filename, BPF_PROG_TYPE_TRACEPOINT, &obj, &bpf_fd))
+#+end_example
+
+It loads all the programs from the object together with maps and
+returns file descriptor of the first one.
+
+To attach the program to the tracepoint we need to create a tracepoint
+perf event and attach the eBPF program to it, using its file descriptor
+via PERF_EVENT_IOC_SET_BPF ioctl call:
+
+#+begin_example sh
+err = ioctl(fd, PERF_EVENT_IOC_SET_BPF, bpf_fd);
+#+end_example
+
+Please check trace_load_and_stats.c load_bpf_and_trace_attach function
+for all the details.
+
+* HASH map
+
+This example is using PERCPU HASH map, that stores number of aborted
+packets for interface
+#+begin_example sh
+struct bpf_map_def SEC("maps") xdp_stats_map = {
+        .type        = BPF_MAP_TYPE_PERCPU_HASH,
+        .key_size    = sizeof(__s32),
+        .value_size  = sizeof(__u64),
+        .max_entries = 10,
+};
+#+end_example
+
+The interface is similar to the ARRAY map except that we need to specifically
+create new element in the hash if it does not exist:
+
+#+begin_example sh
+/* Lookup in kernel BPF-side returns pointer to actual data. */
+valp = bpf_map_lookup_elem(&xdp_stats_map, &key);
+
+/* If there's no record for interface, we need to create one,
+ * with number of packets == 1
+ */
+if (!valp) {
+	__u64 one = 1;
+	return bpf_map_update_elem(&xdp_stats_map, &key, &one, 0) ? 1 : 0;
+}
+
+(*valp)++;
+#+end_example
+
+Please check trace_prog_kern.c for the full code.
+
+* Assignments
+
+** Assignment 1: Setting up your test lab
+
+In this lesson we will use the setup of the previous lesson:
+Basic02 - loading a program by name [[https://github.com/xdp-project/xdp-tutorial/tree/master/basic02-prog-by-name#assignment-2-add-xdp_abort-program]]
+
+and load XDP program from xdp_prog_kern.o that will abort every
+incoming packet:
+
+#+begin_example sh
+SEC("xdp_abort")
+int xdp_drop_func(struct xdp_md *ctx)
+{
+        return XDP_ABORTED;
+}
+#+end_example
+
+with xdp_loader from previous lessson:
+Assignment 2: Add xdp_abort program [[https://github.com/xdp-project/xdp-tutorial/tree/master/basic02-prog-by-name#assignment-2-add-xdp_abort-program]]
+
+Setup the environment:
+
+#+begin_example sh
+$ sudo ../testenv/testenv.sh setup --name veth-basic02
+#+end_example
+
+Load the XDP program, tak produces aborted packets:
+
+#+begin_example sh
+$ sudo ../basic02-prog-by-name/xdp_loader --dev veth-basic02 --force --progsec xdp_abort
+#+end_example
+
+and make some packets:
+
+#+begin_example sh
+$ sudo ../testenv/testenv.sh enter --name veth-basic02
+# ping  fc00:dead:cafe:1::1
+PING fc00:dead:cafe:1::1(fc00:dead:cafe:1::1) 56 data bytes
+#+end_example
+
+** Assignment 2: Load tracepoint monitor program
+
+Now when you run the trace_load_and_stats application it will
+load and attach the tracepoint eBPF program and display number
+of aborted packets per interface:
+
+#+begin_example
+# ./trace_load_and_stats
+Success: Loaded BPF-object(trace_prog_kern.o)
+
+Collecting stats from BPF map
+ - BPF map (bpf_map_type:1) id:46 name:xdp_stats_map key_size:4 value_size:4 max_entries:10
+
+veth-basic02 (2)
+veth-basic02 (4)
+veth-basic02 (6)
+...
+#+end_example

--- a/tracing01-xdp-simple/trace_load_and_stats.c
+++ b/tracing01-xdp-simple/trace_load_and_stats.c
@@ -1,0 +1,313 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+static const char *__doc__ = "XDP loader and stats program\n"
+	" - Allows selecting BPF section --progsec name to XDP-attach to --dev\n";
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <getopt.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <net/if.h>
+
+#include <locale.h>
+#include <unistd.h>
+#include <time.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+
+#include <net/if.h>
+#include <linux/if_link.h> /* depend on kernel-headers installed */
+
+#include <linux/err.h>
+
+#include "../common/common_params.h"
+#include "../common/common_user_bpf_xdp.h"
+#include "../common/common_libbpf.h"
+#include "bpf_util.h" /* bpf_num_possible_cpus */
+
+#include <linux/perf_event.h>
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#include <unistd.h>
+#include <sys/syscall.h>   /* For SYS_xxx definitions */
+#include <sys/ioctl.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX	4096
+#endif
+
+static const char *default_filename = "trace_prog_kern.o";
+
+static const struct option_wrapper long_options[] = {
+	{{"help",        no_argument,		NULL, 'h' },
+	 "Show help", false},
+
+	{{"quiet",       no_argument,		NULL, 'q' },
+	 "Quiet mode (no output)"},
+
+	{{"filename",    required_argument,	NULL,  1  },
+	 "Load program from <file>", "<file>"},
+
+	{{0, 0, NULL,  0 }}
+};
+
+int find_map_fd(struct bpf_object *bpf_obj, const char *mapname)
+{
+	struct bpf_map *map;
+	int map_fd = -1;
+
+	/* Lesson#3: bpf_object to bpf_map */
+	map = bpf_object__find_map_by_name(bpf_obj, mapname);
+        if (!map) {
+		fprintf(stderr, "ERR: cannot find map by name: %s\n", mapname);
+		goto out;
+	}
+
+	map_fd = bpf_map__fd(map);
+ out:
+	return map_fd;
+}
+
+static void stats_print(int map_fd)
+{
+	/* For percpu maps, userspace gets a value per possible CPU */
+	unsigned int nr_cpus = bpf_num_possible_cpus();
+	__u64 values[nr_cpus];
+	__s32 key;
+	void *keyp = &key, *prev_keyp = NULL;
+	int err;
+
+	while (true) {
+		char dev[IF_NAMESIZE];
+		__u64 total = 0;
+		int i;
+
+		err = bpf_map_get_next_key(map_fd, prev_keyp, keyp);
+		if (err) {
+			if (errno == ENOENT)
+				err = 0;
+			break;
+		}
+
+		if ((bpf_map_lookup_elem(map_fd, keyp, values)) != 0) {
+			fprintf(stderr,
+				"ERR: bpf_map_lookup_elem failed key:0x%X\n", key);
+		}
+
+		/* Sum values from each CPU */
+		for (i = 0; i < nr_cpus; i++)
+			total += values[i];
+
+		printf("%s (%llu) ", if_indextoname(key, dev), total);
+		prev_keyp = keyp;
+        }
+
+	printf("\n");
+}
+
+static void stats_poll(int map_fd, __u32 map_type, int interval)
+{
+	/* Trick to pretty printf with thousands separators use %' */
+	setlocale(LC_NUMERIC, "en_US");
+
+	while (1) {
+		stats_print(map_fd);
+		sleep(interval);
+	}
+}
+
+/* Lesson#4: It is userspace responsibility to known what map it is reading and
+ * know the value size. Here get bpf_map_info and check if it match our expected
+ * values.
+ */
+static int __check_map_fd_info(int map_fd, struct bpf_map_info *info,
+			       struct bpf_map_info *exp)
+{
+	__u32 info_len = sizeof(*info);
+	int err;
+
+	if (map_fd < 0)
+		return EXIT_FAIL;
+
+        /* BPF-info via bpf-syscall */
+	err = bpf_obj_get_info_by_fd(map_fd, info, &info_len);
+	if (err) {
+		fprintf(stderr, "ERR: %s() can't get info - %s\n",
+			__func__,  strerror(errno));
+		return EXIT_FAIL_BPF;
+	}
+
+	if (exp->key_size && exp->key_size != info->key_size) {
+		fprintf(stderr, "ERR: %s() "
+			"Map key size(%d) mismatch expected size(%d)\n",
+			__func__, info->key_size, exp->key_size);
+		return EXIT_FAIL;
+	}
+	if (exp->value_size && exp->value_size != info->value_size) {
+		fprintf(stderr, "ERR: %s() "
+			"Map value size(%d) mismatch expected size(%d)\n",
+			__func__, info->value_size, exp->value_size);
+		return EXIT_FAIL;
+	}
+	if (exp->max_entries && exp->max_entries != info->max_entries) {
+		fprintf(stderr, "ERR: %s() "
+			"Map max_entries(%d) mismatch expected size(%d)\n",
+			__func__, info->max_entries, exp->max_entries);
+		return EXIT_FAIL;
+	}
+	if (exp->type && exp->type  != info->type) {
+		fprintf(stderr, "ERR: %s() "
+			"Map type(%d) mismatch expected type(%d)\n",
+			__func__, info->type, exp->type);
+		return EXIT_FAIL;
+	}
+
+	return 0;
+}
+
+int filename__read_int(const char *filename, int *value)
+{
+	char line[64];
+	int fd = open(filename, O_RDONLY), err = -1;
+
+	if (fd < 0)
+		return -1;
+
+	if (read(fd, line, sizeof(line)) > 0) {
+		*value = atoi(line);
+		err = 0;
+	}
+
+	close(fd);
+	return err;
+}
+
+#define TP "/sys/kernel/debug/tracing/events/"
+
+static int read_tp_id(const char *name, int *id)
+{
+	char path[PATH_MAX];
+
+	snprintf(path, PATH_MAX, TP "%s/id", name);
+	return filename__read_int(path, id);
+}
+
+static inline int
+sys_perf_event_open(struct perf_event_attr *attr,
+		    pid_t pid, int cpu, int group_fd,
+		    unsigned long flags)
+{
+	return syscall(__NR_perf_event_open, attr, pid, cpu, group_fd, flags);
+}
+
+static struct bpf_object* load_bpf_and_trace_attach(struct config *cfg)
+{
+	struct perf_event_attr attr;
+	struct bpf_object *obj;
+	int err, bpf_fd;
+	int id, fd;
+
+	if (bpf_prog_load(cfg->filename, BPF_PROG_TYPE_TRACEPOINT, &obj, &bpf_fd)) {
+		fprintf(stderr, "ERR: failed to load program\n");
+		goto err;
+	}
+
+	if (read_tp_id("xdp/xdp_exception", &id)) {
+		fprintf(stderr, "ERR: can't get program section\n");
+		goto err;
+	}
+
+	/* Setup tracepoint perf event */
+	memset(&attr, 0, sizeof(attr));
+	attr.type = PERF_TYPE_TRACEPOINT;
+	attr.config = id;
+	attr.sample_period = 1;
+
+	/* .. and open it */
+	fd = sys_perf_event_open(&attr, -1, 0, -1, 0);
+	if (fd <= 0) {
+		fprintf(stderr, "ERR: failed to open perf event %s\n",
+			strerror(errno));
+		goto err;
+	}
+
+	/* Assign the program to the tracepoint perf event */
+	err = ioctl(fd, PERF_EVENT_IOC_SET_BPF, bpf_fd);
+	if (err) {
+		fprintf(stderr, "ERR: failed to connect perf event with eBPF prog %s\n",
+			strerror(errno));
+		goto err;
+	}
+
+	/* ... and finally enable the event. */
+	err = ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+	if (err) {
+		fprintf(stderr, "ERR: failed to enable perf event %s\n",
+			strerror(errno));
+		goto err;
+	}
+
+	/*
+	 * As far as this program is concerned, we don't care about
+	 * the perf event file descriptor, it will get closed when
+	 * the program is terminated. But normally you want to call
+	 * close(fd) when you stop using it.
+	 */
+	return obj;
+
+err:
+	bpf_object__close(obj);
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	struct bpf_map_info map_expect = { 0 };
+	struct bpf_map_info info = { 0 };
+	struct bpf_object *bpf_obj;
+	struct config cfg;
+	int stats_map_fd;
+	int interval = 2;
+	int err;
+
+	/* Set default BPF-ELF object file and BPF program name */
+	strncpy(cfg.filename, default_filename, sizeof(cfg.filename));
+
+	/* Cmdline options can change progsec */
+	parse_cmdline_args(argc, argv, long_options, &cfg, __doc__);
+
+	bpf_obj = load_bpf_and_trace_attach(&cfg);
+	if (!bpf_obj)
+		return EXIT_FAIL_BPF;
+
+	if (verbose) {
+		printf("Success: Loaded BPF-object(%s)\n", cfg.filename);
+	}
+
+	stats_map_fd = find_map_fd(bpf_obj, "xdp_stats_map");
+	if (stats_map_fd < 0)
+		return EXIT_FAIL_BPF;
+
+	map_expect.key_size    = sizeof(__s32);
+	map_expect.value_size  = sizeof(__u64);
+
+	err = __check_map_fd_info(stats_map_fd, &info, &map_expect);
+	if (err) {
+		fprintf(stderr, "ERR: map via FD not compatible\n");
+		return err;
+	}
+	if (verbose) {
+		printf("\nCollecting stats from BPF map\n");
+		printf(" - BPF map (bpf_map_type:%d) id:%d name:%s"
+		       " key_size:%d value_size:%d max_entries:%d\n",
+		       info.type, info.id, info.name,
+		       info.key_size, info.value_size, info.max_entries
+		       );
+	}
+
+	stats_poll(stats_map_fd, info.type, interval);
+	return EXIT_OK;
+}

--- a/tracing01-xdp-simple/trace_prog_kern.c
+++ b/tracing01-xdp-simple/trace_prog_kern.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include "bpf_helpers.h"
+
+struct bpf_map_def SEC("maps") xdp_stats_map = {
+	.type        = BPF_MAP_TYPE_PERCPU_HASH,
+	.key_size    = sizeof(__s32),
+	.value_size  = sizeof(__u64),
+	.max_entries = 10,
+};
+
+struct xdp_exception_ctx {
+	__u64 __pad;      // First 8 bytes are not accessible by bpf code
+	__s32 prog_id;    //      offset:8;  size:4; signed:1;
+	__u32 act;        //      offset:12; size:4; signed:0;
+	__s32 ifindex;    //      offset:16; size:4; signed:1;
+};
+
+SEC("tracepoint/xdp/xdp_exception")
+int trace_xdp_exception(struct xdp_exception_ctx *ctx)
+{
+	__s32 key = ctx->ifindex;
+	__u32 *valp;
+
+	/* Collecting stats only for XDP_ABORTED action. */
+	if (ctx->act != XDP_ABORTED)
+		return 0;
+
+	/* Lookup in kernel BPF-side returns pointer to actual data. */
+	valp = bpf_map_lookup_elem(&xdp_stats_map, &key);
+
+	/* If there's no record for interface, we need to create one,
+	 * with number of packets == 1
+	 */
+	if (!valp) {
+		__u64 one = 1;
+		return bpf_map_update_elem(&xdp_stats_map, &key, &one, 0) ? 1 : 0;
+	}
+
+	(*valp)++;
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/tracing01-xdp-simple/xdp_prog_kern.c
+++ b/tracing01-xdp-simple/xdp_prog_kern.c
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include "bpf_helpers.h"
+
+SEC("xdp_abort")
+int  xdp_drop_func(struct xdp_md *ctx)
+{
+	return XDP_ABORTED;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/tracing02-xdp-monitor/Makefile
+++ b/tracing02-xdp-monitor/Makefile
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+
+# Departing from the implicit _user.c scheme
+XDP_TARGETS  := trace_prog_kern
+USER_TARGETS := trace_load_and_stats
+
+LIBBPF_DIR = ../libbpf/src/
+COMMON_DIR = ../common/
+
+include $(COMMON_DIR)/common.mk
+

--- a/tracing02-xdp-monitor/README.org
+++ b/tracing02-xdp-monitor/README.org
@@ -1,0 +1,78 @@
+# -*- fill-column: 76; -*-
+#+TITLE: Tutorial: Tracing02 - monitor xdp raw tracepoints
+#+OPTIONS: ^:nil
+
+In this lesson we will show how to attach to and monitor all
+xdp related raw tracepoints and some related info to user space
+stat application.
+
+* Table of Contents                                                     :TOC:
+- [[#raw-tracepoint][RAW tracepoints]]
+  - [[#todo][TODO]]
+- [[#assignments][Assignments]]
+  - [[#assignment-1][Assignment 1: Monitor all xdp tracepoints]]
+
+* RAW tracepoints
+
+The RAW tracepoint is eBPF alternative to standard tracepoint,
+which allows attaching eBPF program to tracepoint without the
+perf layer being involved/executed.
+
+The bpf library expects the raw tracepoint eBPF program to be stored
+in a section with following name:
+
+#+begin_example sh
+raw_tracepoint/tracepoint/sys/tracepoint
+#+end_example
+
+where 'sys' is the tracepoint subsystem and 'tracepoint' is
+the tracepoint name, which can be done with following construct:
+
+#+begin_example sh
+SEC("raw_tracepoint/xdp/xdp_exception")
+int trace_xdp_exception(struct xdp_exception_ctx *ctx)
+#+end_example
+
+The libbpf library exports interface to load and attach raw tracepoint
+programs, following call will load every program in the cfg->filename
+object as raw tracepoint programs:
+
+#+begin_example sh
+err = bpf_prog_load(cfg->filename, BPF_PROG_TYPE_RAW_TRACEPOINT, &obj, &bpf_fd));
+#+end_example
+
+You can then iterate through all the programs and attach
+every program to the raw tracepoint:
+
+#+begin_example sh
+bpf_object__for_each_program(prog, obj) {
+	...
+	bpf_fd = bpf_program__fd(prog);
+	...
+	err = bpf_raw_tracepoint_open(tp, bpf_fd);
+	...
+}
+#+end_example
+
+for more details please check load_bpf_and_trace_attach function
+in trace_load_and_stats.c object.
+
+* Assignments
+
+** Assignment 1: Monitor all xdp tracepoints
+
+#+begin_example sh
+$ sudo ./trace_load_and_stats
+XDP-event       CPU:to  pps          drop-pps     extra-info
+XDP_REDIRECT    total   0            0            Success
+XDP_REDIRECT    total   0            0            Error
+Exception       0       0            11           XDP_UNKNOWN
+Exception       1       0            2            XDP_UNKNOWN
+Exception       2       0            36           XDP_UNKNOWN
+Exception       3       0            29           XDP_UNKNOWN
+Exception       4       0            3            XDP_UNKNOWN
+Exception       5       0            8            XDP_UNKNOWN
+Exception       total   0            91           XDP_UNKNOWN
+cpumap-kthread  total   0            0            0          
+devmap-xmit     total   0            0            0.00        
+#+end_example

--- a/tracing02-xdp-monitor/trace_load_and_stats.c
+++ b/tracing02-xdp-monitor/trace_load_and_stats.c
@@ -1,0 +1,856 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+static const char *__doc__ = "XDP loader and stats program\n"
+	" - Allows selecting BPF section --progsec name to XDP-attach to --dev\n";
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <getopt.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <net/if.h>
+
+#include <locale.h>
+#include <unistd.h>
+#include <time.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+
+#include <net/if.h>
+#include <linux/if_link.h> /* depend on kernel-headers installed */
+
+#include <linux/err.h>
+
+#include "../common/common_params.h"
+#include "../common/common_user_bpf_xdp.h"
+#include "../common/common_libbpf.h"
+#include "bpf_util.h" /* bpf_num_possible_cpus */
+
+#include <linux/perf_event.h>
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#include <unistd.h>
+#include <sys/syscall.h>   /* For SYS_xxx definitions */
+#include <sys/ioctl.h>
+
+enum {
+	REDIR_SUCCESS = 0,
+	REDIR_ERROR = 1,
+};
+
+#define XDP_UNKNOWN	XDP_REDIRECT + 1
+#ifndef XDP_ACTION_MAX
+#define XDP_ACTION_MAX (XDP_UNKNOWN + 1)
+#endif
+
+#define REDIR_RES_MAX 2
+static const char *redir_names[REDIR_RES_MAX] = {
+	[REDIR_SUCCESS]	= "Success",
+	[REDIR_ERROR]	= "Error",
+};
+
+static const char *err2str(int err)
+{
+	if (err < REDIR_RES_MAX)
+		return redir_names[err];
+	return NULL;
+}
+
+/* Common stats data record shared with _kern.c */
+struct datarec {
+	__u64 processed;
+	__u64 dropped;
+	__u64 info;
+	__u64 err;
+};
+
+#define MAX_CPUS 64
+
+/* Userspace structs for collection of stats from maps */
+struct record {
+	__u64 timestamp;
+	struct datarec total;
+	struct datarec *cpu;
+};
+
+struct u64rec {
+	__u64 processed;
+};
+
+struct record_u64 {
+	/* record for _kern side __u64 values */
+	__u64 timestamp;
+	struct u64rec total;
+	struct u64rec *cpu;
+};
+
+struct stats_record {
+	struct record_u64 xdp_redirect[REDIR_RES_MAX];
+	struct record_u64 xdp_exception[XDP_ACTION_MAX];
+	struct record xdp_cpumap_kthread;
+	struct record xdp_cpumap_enqueue[MAX_CPUS];
+	struct record xdp_devmap_xmit;
+};
+
+static const char *default_filename = "trace_prog_kern.o";
+
+static const struct option_wrapper long_options[] = {
+	{{"help",        no_argument,		NULL, 'h' },
+	 "Show help", false},
+
+	{{"quiet",       no_argument,		NULL, 'q' },
+	 "Quiet mode (no output)"},
+
+	{{"filename",    required_argument,	NULL,  1  },
+	 "Load program from <file>", "<file>"},
+
+	{{0, 0, NULL,  0 }}
+};
+
+int find_map_fd(struct bpf_object *bpf_obj, const char *mapname)
+{
+	struct bpf_map *map;
+	int map_fd = -1;
+
+	/* Lesson#3: bpf_object to bpf_map */
+	map = bpf_object__find_map_by_name(bpf_obj, mapname);
+        if (!map) {
+		fprintf(stderr, "ERR: cannot find map by name: %s\n", mapname);
+		goto out;
+	}
+
+	map_fd = bpf_map__fd(map);
+ out:
+	return map_fd;
+}
+
+static int __check_map_fd_info(int map_fd, struct bpf_map_info *info,
+			       struct bpf_map_info *exp)
+{
+	__u32 info_len = sizeof(*info);
+	int err;
+
+	if (map_fd < 0)
+		return EXIT_FAIL;
+
+        /* BPF-info via bpf-syscall */
+	err = bpf_obj_get_info_by_fd(map_fd, info, &info_len);
+	if (err) {
+		fprintf(stderr, "ERR: %s() can't get info - %s\n",
+			__func__,  strerror(errno));
+		return EXIT_FAIL_BPF;
+	}
+
+	if (exp->key_size && exp->key_size != info->key_size) {
+		fprintf(stderr, "ERR: %s() "
+			"Map key size(%d) mismatch expected size(%d)\n",
+			__func__, info->key_size, exp->key_size);
+		return EXIT_FAIL;
+	}
+	if (exp->value_size && exp->value_size != info->value_size) {
+		fprintf(stderr, "ERR: %s() "
+			"Map value size(%d) mismatch expected size(%d)\n",
+			__func__, info->value_size, exp->value_size);
+		return EXIT_FAIL;
+	}
+	if (exp->max_entries && exp->max_entries != info->max_entries) {
+		fprintf(stderr, "ERR: %s() "
+			"Map max_entries(%d) mismatch expected size(%d)\n",
+			__func__, info->max_entries, exp->max_entries);
+		return EXIT_FAIL;
+	}
+	if (exp->type && exp->type  != info->type) {
+		fprintf(stderr, "ERR: %s() "
+			"Map type(%d) mismatch expected type(%d)\n",
+			__func__, info->type, exp->type);
+		return EXIT_FAIL;
+	}
+
+	return 0;
+}
+
+static int __check_map(int map_fd, struct bpf_map_info *exp)
+{
+	struct bpf_map_info info;
+
+	return __check_map_fd_info(map_fd, &info, exp);
+}
+
+static int check_map(const char *name, const struct bpf_map_def *def, int fd)
+{
+	struct {
+		const char          *name;
+		struct bpf_map_info  info;
+	} maps[] = {
+		{
+			.name = "redirect_err_cnt",
+			.info = {
+				.type = BPF_MAP_TYPE_PERCPU_ARRAY,
+				.key_size = sizeof(__u32),
+				.value_size = sizeof(__u64),
+				.max_entries = 2,
+			}
+		},
+		{
+			.name = "exception_cnt",
+			.info = {
+				.type = BPF_MAP_TYPE_PERCPU_ARRAY,
+				.key_size = sizeof(__u32),
+				.value_size = sizeof(__u64),
+				.max_entries = XDP_UNKNOWN + 1,
+			}
+		},
+		{
+			.name = "cpumap_enqueue_cnt",
+			.info = {
+				.type = BPF_MAP_TYPE_PERCPU_ARRAY,
+				.key_size = sizeof(__u32),
+				.value_size = sizeof(struct datarec),
+				.max_entries = MAX_CPUS,
+			}
+		},
+		{
+			.name = "cpumap_kthread_cnt",
+			.info = {
+				.type = BPF_MAP_TYPE_PERCPU_ARRAY,
+				.key_size = sizeof(__u32),
+				.value_size = sizeof(struct datarec),
+				.max_entries = 1,
+			}
+		},
+		{
+			.name = "devmap_xmit_cnt",
+			.info = {
+				.type = BPF_MAP_TYPE_PERCPU_ARRAY,
+				.key_size = sizeof(__u32),
+				.value_size = sizeof(struct datarec),
+				.max_entries = 1,
+			}
+		},
+		{ }
+	};
+	int i = 0;
+
+	fprintf(stdout, "checking map %s\n", name);
+
+	while (maps[i].name) {
+		if (!strcmp(maps[i].name, name))
+			return __check_map(fd, &maps[i].info);
+		i++;
+	}
+
+	fprintf(stdout, "ERR: map %s not found\n", name);
+	return -1;
+}
+
+static int check_maps(struct bpf_object *obj)
+{
+	struct bpf_map *map;
+
+	bpf_object__for_each_map(map, obj) {
+		const struct bpf_map_def *def;
+		const char *name;
+		int fd;
+
+		name = bpf_map__name(map);
+		def  = bpf_map__def(map);
+		fd   = bpf_map__fd(map);
+
+		if (check_map(name, def, fd))
+			return -1;
+	}
+
+	return 0;
+}
+
+#define NANOSEC_PER_SEC 1000000000 /* 10^9 */
+static __u64 gettime(void)
+{
+	struct timespec t;
+	int res;
+
+	res = clock_gettime(CLOCK_MONOTONIC, &t);
+	if (res < 0) {
+		fprintf(stderr, "Error with gettimeofday! (%i)\n", res);
+		exit(-1);
+	}
+	return (__u64) t.tv_sec * NANOSEC_PER_SEC + t.tv_nsec;
+}
+
+static bool map_collect_record(int fd, __u32 key, struct record *rec)
+{
+	/* For percpu maps, userspace gets a value per possible CPU */
+	unsigned int nr_cpus = bpf_num_possible_cpus();
+	struct datarec values[nr_cpus];
+	__u64 sum_processed = 0;
+	__u64 sum_dropped = 0;
+	__u64 sum_info = 0;
+	__u64 sum_err = 0;
+	int i;
+
+	if ((bpf_map_lookup_elem(fd, &key, values)) != 0) {
+		fprintf(stderr,
+			"ERR: bpf_map_lookup_elem failed key:0x%X\n", key);
+		return false;
+	}
+	/* Get time as close as possible to reading map contents */
+	rec->timestamp = gettime();
+
+	/* Record and sum values from each CPU */
+	for (i = 0; i < nr_cpus; i++) {
+		rec->cpu[i].processed = values[i].processed;
+		sum_processed        += values[i].processed;
+		rec->cpu[i].dropped = values[i].dropped;
+		sum_dropped        += values[i].dropped;
+		rec->cpu[i].info = values[i].info;
+		sum_info        += values[i].info;
+		rec->cpu[i].err = values[i].err;
+		sum_err        += values[i].err;
+	}
+	rec->total.processed = sum_processed;
+	rec->total.dropped   = sum_dropped;
+	rec->total.info      = sum_info;
+	rec->total.err       = sum_err;
+	return true;
+}
+
+static bool map_collect_record_u64(int fd, __u32 key, struct record_u64 *rec)
+{
+	/* For percpu maps, userspace gets a value per possible CPU */
+	unsigned int nr_cpus = bpf_num_possible_cpus();
+	struct u64rec values[nr_cpus];
+	__u64 sum_total = 0;
+	int i;
+
+	if ((bpf_map_lookup_elem(fd, &key, values)) != 0) {
+		fprintf(stderr,
+			"ERR: bpf_map_lookup_elem failed key:0x%X\n", key);
+		return false;
+	}
+	/* Get time as close as possible to reading map contents */
+	rec->timestamp = gettime();
+
+	/* Record and sum values from each CPU */
+	for (i = 0; i < nr_cpus; i++) {
+		rec->cpu[i].processed = values[i].processed;
+		sum_total            += values[i].processed;
+	}
+	rec->total.processed = sum_total;
+	return true;
+}
+
+static double calc_period(struct record *r, struct record *p)
+{
+	double period_ = 0;
+	__u64 period = 0;
+
+	period = r->timestamp - p->timestamp;
+	if (period > 0)
+		period_ = ((double) period / NANOSEC_PER_SEC);
+
+	return period_;
+}
+
+static double calc_period_u64(struct record_u64 *r, struct record_u64 *p)
+{
+	double period_ = 0;
+	__u64 period = 0;
+
+	period = r->timestamp - p->timestamp;
+	if (period > 0)
+		period_ = ((double) period / NANOSEC_PER_SEC);
+
+	return period_;
+}
+
+static double calc_pps(struct datarec *r, struct datarec *p, double period)
+{
+	__u64 packets = 0;
+	double pps = 0;
+
+	if (period > 0) {
+		packets = r->processed - p->processed;
+		pps = packets / period;
+	}
+	return pps;
+}
+
+static double calc_pps_u64(struct u64rec *r, struct u64rec *p, double period)
+{
+	__u64 packets = 0;
+	double pps = 0;
+
+	if (period > 0) {
+		packets = r->processed - p->processed;
+		pps = packets / period;
+	}
+	return pps;
+}
+
+static double calc_drop(struct datarec *r, struct datarec *p, double period)
+{
+	__u64 packets = 0;
+	double pps = 0;
+
+	if (period > 0) {
+		packets = r->dropped - p->dropped;
+		pps = packets / period;
+	}
+	return pps;
+}
+
+static double calc_info(struct datarec *r, struct datarec *p, double period)
+{
+	__u64 packets = 0;
+	double pps = 0;
+
+	if (period > 0) {
+		packets = r->info - p->info;
+		pps = packets / period;
+	}
+	return pps;
+}
+
+static double calc_err(struct datarec *r, struct datarec *p, double period)
+{
+	__u64 packets = 0;
+	double pps = 0;
+
+	if (period > 0) {
+		packets = r->err - p->err;
+		pps = packets / period;
+	}
+	return pps;
+}
+
+static void stats_print(struct stats_record *stats_rec,
+			struct stats_record *stats_prev,
+			bool err_only)
+{
+	unsigned int nr_cpus = bpf_num_possible_cpus();
+	int rec_i = 0, i, to_cpu;
+	double t = 0, pps = 0;
+
+	/* Header */
+	printf("%-15s %-7s %-12s %-12s %-9s\n",
+	       "XDP-event", "CPU:to", "pps", "drop-pps", "extra-info");
+
+	/* tracepoint: xdp:xdp_redirect_* */
+	if (err_only)
+		rec_i = REDIR_ERROR;
+
+	for (; rec_i < REDIR_RES_MAX; rec_i++) {
+		struct record_u64 *rec, *prev;
+		char *fmt1 = "%-15s %-7d %'-12.0f %'-12.0f %s\n";
+		char *fmt2 = "%-15s %-7s %'-12.0f %'-12.0f %s\n";
+
+		rec  =  &stats_rec->xdp_redirect[rec_i];
+		prev = &stats_prev->xdp_redirect[rec_i];
+		t = calc_period_u64(rec, prev);
+
+		for (i = 0; i < nr_cpus; i++) {
+			struct u64rec *r = &rec->cpu[i];
+			struct u64rec *p = &prev->cpu[i];
+
+			pps = calc_pps_u64(r, p, t);
+			if (pps > 0)
+				printf(fmt1, "XDP_REDIRECT", i,
+				       rec_i ? 0.0: pps, rec_i ? pps : 0.0,
+				       err2str(rec_i));
+		}
+		pps = calc_pps_u64(&rec->total, &prev->total, t);
+		printf(fmt2, "XDP_REDIRECT", "total",
+		       rec_i ? 0.0: pps, rec_i ? pps : 0.0, err2str(rec_i));
+	}
+
+	/* tracepoint: xdp:xdp_exception */
+	for (rec_i = 0; rec_i < XDP_ACTION_MAX; rec_i++) {
+		struct record_u64 *rec, *prev;
+		char *fmt1 = "%-15s %-7d %'-12.0f %'-12.0f %s\n";
+		char *fmt2 = "%-15s %-7s %'-12.0f %'-12.0f %s\n";
+
+		rec  =  &stats_rec->xdp_exception[rec_i];
+		prev = &stats_prev->xdp_exception[rec_i];
+		t = calc_period_u64(rec, prev);
+
+		for (i = 0; i < nr_cpus; i++) {
+			struct u64rec *r = &rec->cpu[i];
+			struct u64rec *p = &prev->cpu[i];
+
+			pps = calc_pps_u64(r, p, t);
+			if (pps > 0)
+				printf(fmt1, "Exception", i,
+				       0.0, pps, action2str(rec_i));
+		}
+		pps = calc_pps_u64(&rec->total, &prev->total, t);
+		if (pps > 0)
+			printf(fmt2, "Exception", "total",
+			       0.0, pps, action2str(rec_i));
+	}
+
+	/* cpumap enqueue stats */
+	for (to_cpu = 0; to_cpu < MAX_CPUS; to_cpu++) {
+		char *fmt1 = "%-15s %3d:%-3d %'-12.0f %'-12.0f %'-10.2f %s\n";
+		char *fmt2 = "%-15s %3s:%-3d %'-12.0f %'-12.0f %'-10.2f %s\n";
+		struct record *rec, *prev;
+		char *info_str = "";
+		double drop, info;
+
+		rec  =  &stats_rec->xdp_cpumap_enqueue[to_cpu];
+		prev = &stats_prev->xdp_cpumap_enqueue[to_cpu];
+		t = calc_period(rec, prev);
+		for (i = 0; i < nr_cpus; i++) {
+			struct datarec *r = &rec->cpu[i];
+			struct datarec *p = &prev->cpu[i];
+
+			pps  = calc_pps(r, p, t);
+			drop = calc_drop(r, p, t);
+			info = calc_info(r, p, t);
+			if (info > 0) {
+				info_str = "bulk-average";
+				info = pps / info; /* calc average bulk size */
+			}
+			if (pps > 0)
+				printf(fmt1, "cpumap-enqueue",
+				       i, to_cpu, pps, drop, info, info_str);
+		}
+		pps = calc_pps(&rec->total, &prev->total, t);
+		if (pps > 0) {
+			drop = calc_drop(&rec->total, &prev->total, t);
+			info = calc_info(&rec->total, &prev->total, t);
+			if (info > 0) {
+				info_str = "bulk-average";
+				info = pps / info; /* calc average bulk size */
+			}
+			printf(fmt2, "cpumap-enqueue",
+			       "sum", to_cpu, pps, drop, info, info_str);
+		}
+	}
+
+	/* cpumap kthread stats */
+	{
+		char *fmt1 = "%-15s %-7d %'-12.0f %'-12.0f %'-10.0f %s\n";
+		char *fmt2 = "%-15s %-7s %'-12.0f %'-12.0f %'-10.0f %s\n";
+		struct record *rec, *prev;
+		double drop, info;
+		char *i_str = "";
+
+		rec  =  &stats_rec->xdp_cpumap_kthread;
+		prev = &stats_prev->xdp_cpumap_kthread;
+		t = calc_period(rec, prev);
+		for (i = 0; i < nr_cpus; i++) {
+			struct datarec *r = &rec->cpu[i];
+			struct datarec *p = &prev->cpu[i];
+
+			pps  = calc_pps(r, p, t);
+			drop = calc_drop(r, p, t);
+			info = calc_info(r, p, t);
+			if (info > 0)
+				i_str = "sched";
+			if (pps > 0 || drop > 0)
+				printf(fmt1, "cpumap-kthread",
+				       i, pps, drop, info, i_str);
+		}
+		pps = calc_pps(&rec->total, &prev->total, t);
+		drop = calc_drop(&rec->total, &prev->total, t);
+		info = calc_info(&rec->total, &prev->total, t);
+		if (info > 0)
+			i_str = "sched-sum";
+		printf(fmt2, "cpumap-kthread", "total", pps, drop, info, i_str);
+	}
+
+	/* devmap ndo_xdp_xmit stats */
+	{
+		char *fmt1 = "%-15s %-7d %'-12.0f %'-12.0f %'-10.2f %s %s\n";
+		char *fmt2 = "%-15s %-7s %'-12.0f %'-12.0f %'-10.2f %s %s\n";
+		struct record *rec, *prev;
+		double drop, info, err;
+		char *i_str = "";
+		char *err_str = "";
+
+		rec  =  &stats_rec->xdp_devmap_xmit;
+		prev = &stats_prev->xdp_devmap_xmit;
+		t = calc_period(rec, prev);
+		for (i = 0; i < nr_cpus; i++) {
+			struct datarec *r = &rec->cpu[i];
+			struct datarec *p = &prev->cpu[i];
+
+			pps  = calc_pps(r, p, t);
+			drop = calc_drop(r, p, t);
+			info = calc_info(r, p, t);
+			err  = calc_err(r, p, t);
+			if (info > 0) {
+				i_str = "bulk-average";
+				info = (pps+drop) / info; /* calc avg bulk */
+			}
+			if (err > 0)
+				err_str = "drv-err";
+			if (pps > 0 || drop > 0)
+				printf(fmt1, "devmap-xmit",
+				       i, pps, drop, info, i_str, err_str);
+		}
+		pps = calc_pps(&rec->total, &prev->total, t);
+		drop = calc_drop(&rec->total, &prev->total, t);
+		info = calc_info(&rec->total, &prev->total, t);
+		err  = calc_err(&rec->total, &prev->total, t);
+		if (info > 0) {
+			i_str = "bulk-average";
+			info = (pps+drop) / info; /* calc avg bulk */
+		}
+		if (err > 0)
+			err_str = "drv-err";
+		printf(fmt2, "devmap-xmit", "total", pps, drop,
+		       info, i_str, err_str);
+	}
+
+	printf("\n");
+}
+
+static int map_fd(struct bpf_object *obj, const char *name)
+{
+	struct bpf_map *map;
+
+	map = bpf_object__find_map_by_name(obj, name);
+	if (map)
+		return bpf_map__fd(map);
+
+	return -1;
+}
+
+static bool stats_collect(struct bpf_object *obj, struct stats_record *rec)
+{
+	int fd;
+	int i;
+
+	/* TODO: Detect if someone unloaded the perf event_fd's, as
+	 * this can happen by someone running perf-record -e
+	 */
+
+	fd = map_fd(obj, "redirect_err_cnt");
+
+	for (i = 0; i < REDIR_RES_MAX; i++)
+		map_collect_record_u64(fd, i, &rec->xdp_redirect[i]);
+
+	fd = map_fd(obj, "exception_cnt");
+
+	for (i = 0; i < XDP_ACTION_MAX; i++) {
+		map_collect_record_u64(fd, i, &rec->xdp_exception[i]);
+	}
+
+	fd = map_fd(obj, "cpumap_enqueue_cnt");
+
+	for (i = 0; i < MAX_CPUS; i++)
+		map_collect_record(fd, i, &rec->xdp_cpumap_enqueue[i]);
+
+	fd = map_fd(obj, "cpumap_kthread_cnt");
+
+	map_collect_record(fd, 0, &rec->xdp_cpumap_kthread);
+
+	fd = map_fd(obj, "devmap_xmit_cnt");
+
+	map_collect_record(fd, 0, &rec->xdp_devmap_xmit);
+
+	return true;
+}
+
+static void *alloc_rec_per_cpu(int record_size)
+{
+	unsigned int nr_cpus = bpf_num_possible_cpus();
+	void *array;
+	size_t size;
+
+	size = record_size * nr_cpus;
+	array = malloc(size);
+	memset(array, 0, size);
+	if (!array) {
+		fprintf(stderr, "Mem alloc error (nr_cpus:%u)\n", nr_cpus);
+		exit(-1);
+	}
+	return array;
+}
+
+static struct stats_record *alloc_stats_record(void)
+{
+	struct stats_record *rec;
+	int rec_sz;
+	int i;
+
+	/* Alloc main stats_record structure */
+	rec = malloc(sizeof(*rec));
+	memset(rec, 0, sizeof(*rec));
+	if (!rec) {
+		fprintf(stderr, "Mem alloc error\n");
+		exit(-1);
+	}
+
+	/* Alloc stats stored per CPU for each record */
+	rec_sz = sizeof(struct u64rec);
+	for (i = 0; i < REDIR_RES_MAX; i++)
+		rec->xdp_redirect[i].cpu = alloc_rec_per_cpu(rec_sz);
+
+	for (i = 0; i < XDP_ACTION_MAX; i++)
+		rec->xdp_exception[i].cpu = alloc_rec_per_cpu(rec_sz);
+
+	rec_sz = sizeof(struct datarec);
+	rec->xdp_cpumap_kthread.cpu = alloc_rec_per_cpu(rec_sz);
+	rec->xdp_devmap_xmit.cpu    = alloc_rec_per_cpu(rec_sz);
+
+	for (i = 0; i < MAX_CPUS; i++)
+		rec->xdp_cpumap_enqueue[i].cpu = alloc_rec_per_cpu(rec_sz);
+
+	return rec;
+}
+
+static void free_stats_record(struct stats_record *r)
+{
+	int i;
+
+	for (i = 0; i < REDIR_RES_MAX; i++)
+		free(r->xdp_redirect[i].cpu);
+
+	for (i = 0; i < XDP_ACTION_MAX; i++)
+		free(r->xdp_exception[i].cpu);
+
+	free(r->xdp_cpumap_kthread.cpu);
+	free(r->xdp_devmap_xmit.cpu);
+
+	for (i = 0; i < MAX_CPUS; i++)
+		free(r->xdp_cpumap_enqueue[i].cpu);
+
+	free(r);
+}
+
+/* Pointer swap trick */
+static inline void swap(struct stats_record **a, struct stats_record **b)
+{
+	struct stats_record *tmp;
+
+	tmp = *a;
+	*a = *b;
+	*b = tmp;
+}
+
+static void stats_poll(struct bpf_object *obj, int interval, bool err_only)
+{
+	struct stats_record *rec, *prev;
+
+	rec  = alloc_stats_record();
+	prev = alloc_stats_record();
+	stats_collect(obj, rec);
+
+	if (err_only)
+		printf("\n%s\n", "???");
+
+	/* Trick to pretty printf with thousands separators use %' */
+	setlocale(LC_NUMERIC, "en_US");
+
+	while (1) {
+		swap(&prev, &rec);
+		stats_collect(obj, rec);
+		stats_print(rec, prev, err_only);
+		fflush(stdout);
+		sleep(interval);
+	}
+
+	free_stats_record(rec);
+	free_stats_record(prev);
+}
+
+
+int filename__read_int(const char *filename, int *value)
+{
+	char line[64];
+	int fd = open(filename, O_RDONLY), err = -1;
+
+	if (fd < 0)
+		return -1;
+
+	if (read(fd, line, sizeof(line)) > 0) {
+		*value = atoi(line);
+		err = 0;
+	}
+
+	close(fd);
+	return err;
+}
+
+static inline int
+sys_perf_event_open(struct perf_event_attr *attr,
+		    pid_t pid, int cpu, int group_fd,
+		    unsigned long flags)
+{
+	return syscall(__NR_perf_event_open, attr, pid, cpu, group_fd, flags);
+}
+
+static struct bpf_object* load_bpf_and_trace_attach(struct config *cfg)
+{
+	struct bpf_object *obj;
+	struct bpf_program *prog;
+	int bpf_fd, err;
+
+	if (bpf_prog_load(cfg->filename, BPF_PROG_TYPE_RAW_TRACEPOINT, &obj, &bpf_fd)) {
+		fprintf(stderr, "ERR: failed to load program\n");
+		return NULL;
+	}
+
+	bpf_object__for_each_program(prog, obj) {
+		const char *sec = bpf_program__title(prog, true);
+		char *tp;
+
+		if (!sec) {
+			fprintf(stderr, "ERR: failed to get program title\n");
+			goto err;
+		}
+
+		tp = strrchr(sec, '/');
+		if (!tp) {
+			fprintf(stderr, "ERR: wrong program title %s\n", sec);
+			goto err;
+		}
+
+		tp++;
+		bpf_fd = bpf_program__fd(prog);
+
+		err = bpf_raw_tracepoint_open(tp, bpf_fd);
+		if (err < 0) {
+			fprintf(stderr, "ERR: failed to open raw tracepoint for %s, (%d %s)\n",
+				tp, -errno, strerror(errno));
+			goto err;
+		}
+	}
+
+	return obj;
+
+err:
+	bpf_object__close(obj);
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	struct bpf_object *bpf_obj;
+	struct config cfg;
+	int interval = 2;
+
+	/* Set default BPF-ELF object file and BPF program name */
+	strncpy(cfg.filename, default_filename, sizeof(cfg.filename));
+
+	/* Cmdline options can change progsec */
+	parse_cmdline_args(argc, argv, long_options, &cfg, __doc__);
+
+	bpf_obj = load_bpf_and_trace_attach(&cfg);
+	if (!bpf_obj)
+		return EXIT_FAIL_BPF;
+
+	if (verbose) {
+		printf("Success: Loaded BPF-object(%s)\n", cfg.filename);
+	}
+
+	if (check_maps(bpf_obj))
+		return EXIT_FAIL_BPF;
+
+	stats_poll(bpf_obj, interval, false);
+	return EXIT_OK;
+}

--- a/tracing02-xdp-monitor/trace_prog_kern.c
+++ b/tracing02-xdp-monitor/trace_prog_kern.c
@@ -1,0 +1,254 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include "bpf_helpers.h"
+
+struct bpf_map_def SEC("maps") redirect_err_cnt = {
+	.type		= BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size	= sizeof(__u32),
+	.value_size	= sizeof(__u64),
+	.max_entries	= 2,
+	/* TODO: have entries for all possible errno's */
+};
+
+#define XDP_UNKNOWN	XDP_REDIRECT + 1
+struct bpf_map_def SEC("maps") exception_cnt = {
+	.type		= BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size	= sizeof(__u32),
+	.value_size	= sizeof(__u64),
+	.max_entries	= 6, //XDP_UNKNOWN + 1,
+};
+
+/* Tracepoint format: /sys/kernel/debug/tracing/events/xdp/xdp_redirect/format
+ * Code in:                kernel/include/trace/events/xdp.h
+ */
+struct xdp_redirect_ctx {
+	__u64 __pad;		// First 8 bytes are not accessible by bpf code
+	int prog_id;		//	offset:8;  size:4; signed:1;
+	__u32 act;		//	offset:12  size:4; signed:0;
+	int ifindex;		//	offset:16  size:4; signed:1;
+	int err;		//	offset:20  size:4; signed:1;
+	int to_ifindex;		//	offset:24  size:4; signed:1;
+	__u32 map_id;		//	offset:28  size:4; signed:0;
+	int map_index;		//	offset:32  size:4; signed:1;
+};				//	offset:36
+
+enum {
+	XDP_REDIRECT_SUCCESS = 0,
+	XDP_REDIRECT_ERROR = 1
+};
+
+static __always_inline
+int xdp_redirect_collect_stat(struct xdp_redirect_ctx *ctx)
+{
+	__u32 key = XDP_REDIRECT_ERROR;
+	int err = ctx->err;
+	__u64 *cnt;
+
+	if (!err)
+		key = XDP_REDIRECT_SUCCESS;
+
+	cnt  = bpf_map_lookup_elem(&redirect_err_cnt, &key);
+	if (!cnt)
+		return 1;
+	*cnt += 1;
+
+	return 0; /* Indicate event was filtered (no further processing)*/
+	/*
+	 * Returning 1 here would allow e.g. a perf-record tracepoint
+	 * to see and record these events, but it doesn't work well
+	 * in-practice as stopping perf-record also unload this
+	 * bpf_prog.  Plus, there is additional overhead of doing so.
+	 */
+}
+
+SEC("raw_tracepoint/xdp/xdp_redirect_err")
+int trace_xdp_redirect_err(struct xdp_redirect_ctx *ctx)
+{
+	return xdp_redirect_collect_stat(ctx);
+}
+
+SEC("raw_tracepoint/xdp/xdp_redirect_map_err")
+int trace_xdp_redirect_map_err(struct xdp_redirect_ctx *ctx)
+{
+	return xdp_redirect_collect_stat(ctx);
+}
+
+/* Likely unloaded when prog starts */
+SEC("raw_tracepoint/xdp/xdp_redirect")
+int trace_xdp_redirect(struct xdp_redirect_ctx *ctx)
+{
+	return xdp_redirect_collect_stat(ctx);
+}
+
+/* Likely unloaded when prog starts */
+SEC("raw_tracepoint/xdp/xdp_redirect_map")
+int trace_xdp_redirect_map(struct xdp_redirect_ctx *ctx)
+{
+	return xdp_redirect_collect_stat(ctx);
+}
+
+/* Tracepoint format: /sys/kernel/debug/tracing/events/xdp/xdp_exception/format
+ * Code in:                kernel/include/trace/events/xdp.h
+ */
+struct xdp_exception_ctx {
+	__u64 __pad;	// First 8 bytes are not accessible by bpf code
+	int prog_id;	//	offset:8;  size:4; signed:1;
+	__u32 act;	//	offset:12; size:4; signed:0;
+	int ifindex;	//	offset:16; size:4; signed:1;
+};
+
+SEC("raw_tracepoint/xdp/xdp_exception")
+int trace_xdp_exception(struct xdp_exception_ctx *ctx)
+{
+	__u64 *cnt;
+	__u32 key;
+
+	key = ctx->act;
+	if (key > XDP_REDIRECT)
+		key = XDP_UNKNOWN;
+
+	cnt = bpf_map_lookup_elem(&exception_cnt, &key);
+	if (!cnt)
+		return 1;
+	*cnt += 1;
+
+	return 0;
+}
+
+/* Common stats data record shared with _user.c */
+struct datarec {
+	__u64 processed;
+	__u64 dropped;
+	__u64 info;
+	__u64 err;
+};
+#define MAX_CPUS 64
+
+struct bpf_map_def SEC("maps") cpumap_enqueue_cnt = {
+	.type		= BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size	= sizeof(__u32),
+	.value_size	= sizeof(struct datarec),
+	.max_entries	= MAX_CPUS,
+};
+
+struct bpf_map_def SEC("maps") cpumap_kthread_cnt = {
+	.type		= BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size	= sizeof(__u32),
+	.value_size	= sizeof(struct datarec),
+	.max_entries	= 1,
+};
+
+/* Tracepoint: /sys/kernel/debug/tracing/events/xdp/xdp_cpumap_enqueue/format
+ * Code in:         kernel/include/trace/events/xdp.h
+ */
+struct cpumap_enqueue_ctx {
+	__u64 __pad;		// First 8 bytes are not accessible by bpf code
+	int map_id;		//	offset:8;  size:4; signed:1;
+	__u32 act;		//	offset:12; size:4; signed:0;
+	int cpu;		//	offset:16; size:4; signed:1;
+	unsigned int drops;	//	offset:20; size:4; signed:0;
+	unsigned int processed;	//	offset:24; size:4; signed:0;
+	int to_cpu;		//	offset:28; size:4; signed:1;
+};
+
+SEC("raw_tracepoint/xdp/xdp_cpumap_enqueue")
+int trace_xdp_cpumap_enqueue(struct cpumap_enqueue_ctx *ctx)
+{
+	__u32 to_cpu = ctx->to_cpu;
+	struct datarec *rec;
+
+	if (to_cpu >= MAX_CPUS)
+		return 1;
+
+	rec = bpf_map_lookup_elem(&cpumap_enqueue_cnt, &to_cpu);
+	if (!rec)
+		return 0;
+	rec->processed += ctx->processed;
+	rec->dropped   += ctx->drops;
+
+	/* Record bulk events, then userspace can calc average bulk size */
+	if (ctx->processed > 0)
+		rec->info += 1;
+
+	return 0;
+}
+
+/* Tracepoint: /sys/kernel/debug/tracing/events/xdp/xdp_cpumap_kthread/format
+ * Code in:         kernel/include/trace/events/xdp.h
+ */
+struct cpumap_kthread_ctx {
+	__u64 __pad;		// First 8 bytes are not accessible by bpf code
+	int map_id;		//	offset:8;  size:4; signed:1;
+	__u32 act;		//	offset:12; size:4; signed:0;
+	int cpu;		//	offset:16; size:4; signed:1;
+	unsigned int drops;	//	offset:20; size:4; signed:0;
+	unsigned int processed;	//	offset:24; size:4; signed:0;
+	int sched;		//	offset:28; size:4; signed:1;
+};
+
+SEC("raw_tracepoint/xdp/xdp_cpumap_kthread")
+int trace_xdp_cpumap_kthread(struct cpumap_kthread_ctx *ctx)
+{
+	struct datarec *rec;
+	__u32 key = 0;
+
+	rec = bpf_map_lookup_elem(&cpumap_kthread_cnt, &key);
+	if (!rec)
+		return 0;
+	rec->processed += ctx->processed;
+	rec->dropped   += ctx->drops;
+
+	/* Count times kthread yielded CPU via schedule call */
+	if (ctx->sched)
+		rec->info++;
+
+	return 0;
+}
+
+struct bpf_map_def SEC("maps") devmap_xmit_cnt = {
+	.type		= BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size	= sizeof(__u32),
+	.value_size	= sizeof(struct datarec),
+	.max_entries	= 1,
+};
+
+/* Tracepoint: /sys/kernel/debug/tracing/events/xdp/xdp_devmap_xmit/format
+ * Code in:         kernel/include/trace/events/xdp.h
+ */
+struct devmap_xmit_ctx {
+	__u64 __pad;		// First 8 bytes are not accessible by bpf code
+	int map_id;		//	offset:8;  size:4; signed:1;
+	__u32 act;		//	offset:12; size:4; signed:0;
+	__u32 map_index;		//	offset:16; size:4; signed:0;
+	int drops;		//	offset:20; size:4; signed:1;
+	int sent;		//	offset:24; size:4; signed:1;
+	int from_ifindex;	//	offset:28; size:4; signed:1;
+	int to_ifindex;		//	offset:32; size:4; signed:1;
+	int err;		//	offset:36; size:4; signed:1;
+};
+
+SEC("raw_tracepoint/xdp/xdp_devmap_xmit")
+int trace_xdp_devmap_xmit(struct devmap_xmit_ctx *ctx)
+{
+	struct datarec *rec;
+	__u32 key = 0;
+
+	rec = bpf_map_lookup_elem(&devmap_xmit_cnt, &key);
+	if (!rec)
+		return 0;
+	rec->processed += ctx->sent;
+	rec->dropped   += ctx->drops;
+
+	/* Record bulk events, then userspace can calc average bulk size */
+	rec->info += 1;
+
+	/* Record error cases, where no frame were sent */
+	if (ctx->err)
+		rec->err++;
+
+	/* Catch API error of drv ndo_xdp_xmit sent more than count */
+	if (ctx->drops < 0)
+		rec->err++;
+
+	return 1;
+}

--- a/tracing03-xdp-debug-print/Makefile
+++ b/tracing03-xdp-debug-print/Makefile
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+
+XDP_TARGETS := xdp_prog_kern
+USER_TARGETS := trace_read
+
+LLC ?= llc
+CLANG ?= clang
+CC := gcc
+
+LIBBPF_DIR = ../libbpf/src/
+COMMON_DIR = ../common/
+
+include $(COMMON_DIR)/common.mk
+COMMON_OBJS := $(COMMON_DIR)/common_params.o

--- a/tracing03-xdp-debug-print/README.org
+++ b/tracing03-xdp-debug-print/README.org
@@ -87,7 +87,7 @@ $ sudo ../testenv/testenv.sh setup --name veth-basic02
 #+end_example
 
 Load XDP program from xdp_prog_kern.o that will print
-ethertnet header on every incomming packet:
+ethertnet header on every incoming packet:
 
 #+begin_example sh
 $ sudo ../basic02-prog-by-name/xdp_loader --dev veth-basic02 --force --progsec xdp

--- a/tracing03-xdp-debug-print/README.org
+++ b/tracing03-xdp-debug-print/README.org
@@ -1,0 +1,131 @@
+# -*- fill-column: 76; -*-
+#+TITLE: Tutorial: Tracing03 - debug print
+#+OPTIONS: ^:nil
+
+In this lesson we will show how to print message from eBPF program
+into tracefs buffer.
+
+* Table of Contents                                                     :TOC:
+- [[#bpf-trace-printk][eBPF trace printk helper]]
+- [[#tracefs-pipe-reader][The tracefs pipe reader]]
+- [[#assignments][Assignments]]
+  - [[#assignment-1-setting-up-your-test-lab][Assignment 1: Setting up your test lab]]
+  - [[#assignment-2-bpf-trace-printk][Assignment 2: Run debug code]]
+
+
+* eBPF trace printk helper
+
+The bpf_trace_print helper function is very useful when debugging or
+when there's need for immediate feedback from the eBPF program.
+
+It offers limited trace_printk capability and basically stores message
+into the tracefs buffer.
+
+The bpf_trace_printk interface is:
+
+#+begin_example sh
+/*
+ * Only limited trace_printk() conversion specifiers allowed:
+ * %d %i %u %x %ld %li %lu %lx %lld %lli %llu %llx %p %s
+ */
+BPF_CALL_5(bpf_trace_printk, char *, fmt, u32, fmt_size, u64, arg1,
+           u64, arg2, u64, arg3)
+#+end_example
+
+Because the above interface requires to put the size of the format
+string it's more convenient to use following macro, which allows
+alone string argument to be passed:
+
+#+begin_example sh
+#define bpf_printk(fmt, ...)                                    \
+({                                                              \
+        char ____fmt[] = fmt;                                   \
+        bpf_trace_printk(____fmt, sizeof(____fmt),              \
+                         ##__VA_ARGS__);                        \
+})
+
+SEC("xdp")
+int xdp_prog_simple(struct xdp_md *ctx)
+{
+        bpf_printk("...");
+        return XDP_PASS;
+}
+#+end_example
+
+* The tracefs pipe reader
+
+To retrieve the message printed by bpf_trace_printk, you can either
+read tracefs buffer directly:
+
+#+begin_example sh
+$ sudo cat /sys/kernel/debug/tracing/trace_pipe
+#+end_example
+
+Or you can use standard C file-reading/parsing code to get the data:
+
+#+begin_example sh
+stream = fopen(TRACEFS_PIPE, "r");
+
+...
+
+while ((nread = getline(&line, &len, stream)) != -1) {
+#+end_example
+
+for more details please check on trace_read.c file.
+
+* Assignments
+
+** Assignment 1: Setting up your test lab
+
+In this lesson we will use the setup of the previous lesson:
+Basic02 - loading a program by name [[https://github.com/xdp-project/xdp-tutorial/tree/master/basic02-prog-by-name#assignment-2-add-xdp_abort-program]]
+
+Setup the environment:
+
+#+begin_example sh
+$ sudo ../testenv/testenv.sh setup --name veth-basic02
+#+end_example
+
+Load XDP program from xdp_prog_kern.o that will print
+ethertnet header on every incomming packet:
+
+#+begin_example sh
+$ sudo ../basic02-prog-by-name/xdp_loader --dev veth-basic02 --force --progsec xdp
+#+end_example
+
+and make some packets:
+
+#+begin_example sh
+$ sudo ../testenv/testenv.sh enter --name veth-basic02
+# ping  fc00:dead:cafe:1::1
+PING fc00:dead:cafe:1::1(fc00:dead:cafe:1::1) 56 data bytes
+#+end_example
+
+- Assignment 2: Run debug code
+
+#+begin_example sh
+bpf_printk("src: %llu, dst: %llu, proto: %u\n",
+           ether_addr_to_u64(eth->h_source),
+           ether_addr_to_u64(eth->h_dest),
+           bpf_ntohs(eth->h_proto));
+#+end_example
+
+You can monitor the message either via tracefs:
+
+#+begin_example sh
+$ sudo cat /sys/kernel/debug/tracing/trace_pipe
+ping-28172 [001] ..s1 155229.100016: 0: src: 99726513069783, dst: 63819112930922, proto: 56710
+ping-28172 [001] ..s1 155230.124054: 0: src: 99726513069783, dst: 63819112930922, proto: 56710
+ping-28172 [001] ..s1 155231.148018: 0: src: 99726513069783, dst: 63819112930922, proto: 56710
+ping-28172 [001] ..s1 155232.172022: 0: src: 99726513069783, dst: 63819112930922, proto: 56710
+#+end_example
+
+or with the trace_read application:
+
+#+begin_example sh
+$ sudo ./trace_read
+src: 5a:b3:63:62:de:d7 dst: 3a:b:b:8e:5e:6a proto: 56710
+src: 5a:b3:63:62:de:d7 dst: 3a:b:b:8e:5e:6a proto: 56710
+src: 5a:b3:63:62:de:d7 dst: 3a:b:b:8e:5e:6a proto: 56710
+...
+#+end_example

--- a/tracing03-xdp-debug-print/trace_read.c
+++ b/tracing03-xdp-debug-print/trace_read.c
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../common/common_defines.h"
+#include <netinet/ether.h>
+
+#define TRACEFS_PIPE "/sys/kernel/debug/tracing/trace_pipe"
+
+#ifndef PATH_MAX
+#define PATH_MAX	4096
+#endif
+
+static void print_ether_addr(const char *type, char *str)
+{
+	__u64 addr;
+
+	if (1 != sscanf(str, "%llu", &addr))
+		return;
+
+	printf("%s: %s ", type, ether_ntoa((struct ether_addr *) &addr));
+}
+
+int main(int argc, char **argv)
+{
+	FILE *stream;
+	char *line = NULL;
+	size_t len = 0;
+	ssize_t nread;
+
+	stream = fopen(TRACEFS_PIPE, "r");
+	if (stream == NULL) {
+		perror("fopen");
+		exit(EXIT_FAILURE);
+	}
+
+
+	while ((nread = getline(&line, &len, stream)) != -1) {
+		char *tok, *saveptr;
+		unsigned int proto;
+
+		tok = strtok_r(line, " ", &saveptr);
+
+		while (tok) {
+			if (!strncmp(tok, "src:", 4)) {
+				tok = strtok_r(NULL, " ", &saveptr);
+				print_ether_addr("src", tok);
+			}
+
+			if (!strncmp(tok, "dst:", 4)) {
+				tok = strtok_r(NULL, " ", &saveptr);
+				print_ether_addr("dst", tok);
+			}
+
+			if (!strncmp(tok, "proto:", 5)) {
+				tok = strtok_r(NULL, " ", &saveptr);
+				if (1 == sscanf(tok, "%u", &proto))
+					printf("proto: %u", proto);
+			}
+			tok = strtok_r(NULL, " ", &saveptr);
+		}
+
+		printf("\n");
+	}
+
+	free(line);
+	fclose(stream);
+	return EXIT_OK;
+}

--- a/tracing03-xdp-debug-print/xdp_prog_kern.c
+++ b/tracing03-xdp-debug-print/xdp_prog_kern.c
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/if_vlan.h>
+#include <linux/ip.h>
+#include <linux/in.h>
+#include <stdbool.h>
+#include "bpf_helpers.h"
+#include "bpf_endian.h"
+
+#define bpf_printk(fmt, ...)                                    \
+({                                                              \
+	char ____fmt[] = fmt;                                   \
+	bpf_trace_printk(____fmt, sizeof(____fmt),              \
+                         ##__VA_ARGS__);                        \
+})
+
+/* to u64 in host order */
+static inline __u64 ether_addr_to_u64(const __u8 *addr)
+{
+	__u64 u = 0;
+	int i;
+
+	for (i = ETH_ALEN; i >= 0; i--)
+		u = u << 8 | addr[i];
+	return u;
+}
+
+SEC("xdp")
+int  xdp_prog_simple(struct xdp_md *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	struct ethhdr *eth = data;
+	__u64 offset = sizeof(*eth);
+
+	if ((void *)eth + offset > data_end)
+		return 0;
+
+	bpf_printk("src: %llu, dst: %llu, proto: %u\n",
+		   ether_addr_to_u64(eth->h_source),
+		   ether_addr_to_u64(eth->h_dest),
+		   bpf_ntohs(eth->h_proto));
+
+	return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/tracing04-xdp-tcpdump/Makefile
+++ b/tracing04-xdp-tcpdump/Makefile
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+
+XDP_TARGETS := xdp_sample_pkts_kern
+USER_TARGETS := xdp_sample_pkts_user
+USER_LIBS=-lpcap
+
+LLC ?= llc
+CLANG ?= clang
+CC := gcc
+
+LIBBPF_DIR = ../libbpf/src/
+COMMON_DIR = ../common/
+
+include $(COMMON_DIR)/common.mk
+COMMON_OBJS := $(COMMON_DIR)/common_params.o

--- a/tracing04-xdp-tcpdump/README.org
+++ b/tracing04-xdp-tcpdump/README.org
@@ -1,0 +1,119 @@
+# -*- fill-column: 76; -*-
+#+TITLE: Tutorial: Tracing04 - tcpdump
+#+OPTIONS: ^:nil
+
+In this lesson we will show how to dump the packet samples
+from XDP program all the way to the pcap dump file.
+
+
+* Table of Contents                                                     :TOC:
+- [[#dump-the-packet-sample][Dump the packet sample]]
+- [[#assignments][Assignments]]
+  - [[#assignment-1-setup][Assignment 1: Setting up your test lab]]
+  - [[#assignment-2-pcap-dump][Assignment 2: The PCAP dump file]]
+
+* Dump the packet sample
+
+In this example we will show how to send data and packet sample
+into user space via perf event.
+
+First you need to define the event map, which will allow you
+to send events to the user space via perf event ring buffer:
+
+#+begin_example sh
+struct bpf_map_def SEC("maps") my_map = {
+        .type		= BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+        .key_size	= sizeof(int),
+        .value_size	= sizeof(__u32),
+        .max_entries	= MAX_CPUS,
+};
+#+end_example
+
+The value_size determines the size of the event data we will
+be posting to the user space through perf event ring buffer.
+In our case it's sizeof(u32) which is size of following structure:
+
+#+begin_example sh
+struct S {
+        __u16 cookie;
+        __u16 pkt_len;
+} __packed;
+#+end_example
+
+We set the values of the event (metadata variable) and pass them
+into the bpf_perf_event_output call:
+
+#+begin_example sh
+int xdp_sample_prog(struct xdp_md *ctx)
+{
+        void *data_end = (void *)(long)ctx->data_end;
+        void *data = (void *)(long)ctx->data;
+
+	...
+
+        __u64 flags = BPF_F_CURRENT_CPU;
+        struct S metadata;
+
+        metadata.cookie = 0xdead;
+        metadata.pkt_len = (__u16)(data_end - data);
+
+	ret = bpf_perf_event_output(ctx, &my_map, flags,
+				    &metadata, sizeof(metadata));
+	...
+#+end_example
+
+To add the actual packet dump to the event, we can
+set flags upper 32 bits with the size of the requested sample
+and the bpf_perf_event_output will attach the specified
+amount of bytes from packet to the perf event:
+
+
+#+begin_example sh
+__u64 flags = BPF_F_CURRENT_CPU;
+
+flags |= (__u64)sample_size << 32;
+
+ret = bpf_perf_event_output(ctx, &my_map, flags,
+                            &metadata, sizeof(metadata));
+#+end_example
+
+Please check the whole eBPF code in xdp_sample_pkts_kern.c file.
+
+* Assignments
+
+** Assignment 1: Setting up your test lab
+
+In this lesson we will use the setup of the previous lesson:
+Basic02 - loading a program by name [[https://github.com/xdp-project/xdp-tutorial/tree/master/basic02-prog-by-name#assignment-2-add-xdp_abort-program]]
+
+#+begin_example sh
+$ sudo ../testenv/testenv.sh setup --name veth-basic02
+#+end_example
+
+and make some packets:
+
+#+begin_example sh
+$ sudo ../testenv/testenv.sh enter --name veth-basic02
+# ping  fc00:dead:cafe:1::1
+PING fc00:dead:cafe:1::1(fc00:dead:cafe:1::1) 56 data bytes
+#+end_example
+
+** Assignment 2: The PCAP dump file
+
+Load the eBPF kernel packets dump program and store the packets to the dump file:
+
+#+begin_example sh
+$ sudo ./xdp_sample_pkts_user -d veth-basic02 -F
+pkt len: 118   bytes. hdr: 76 58 28 55 df 4e fa e2 b6 27 8e 79 86 dd 60 0d 48 1b 00 40 3a 40 fc 00 de ad ca fe 00 ...
+pkt len: 118   bytes. hdr: 76 58 28 55 df 4e fa e2 b6 27 8e 79 86 dd 60 0d 48 1b 00 40 3a 40 fc 00 de ad ca fe 00 ...
+^C
+2 packet samples stored in samples.pcap
+#+end_example
+
+Check the pcap dump with the tcpdump application:
+#+begin_example sh
+$ tcpdump -r ./samples.pcap
+reading from file ./samples.pcap, link-type EN10MB (Ethernet)
+12:12:04.553039 IP6 fc00:dead:cafe:1::2 > krava: ICMP6, echo request, seq 2177, length 64
+12:12:05.576864 IP6 fc00:dead:cafe:1::2 > krava: ICMP6, echo request, seq 2178, length 64
+#+end_example

--- a/tracing04-xdp-tcpdump/xdp_sample_pkts_kern.c
+++ b/tracing04-xdp-tcpdump/xdp_sample_pkts_kern.c
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/bpf.h>
+#include <string.h>
+#include "bpf_helpers.h"
+
+#define SAMPLE_SIZE 1024ul
+#define MAX_CPUS 128
+
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+
+#define min(x, y) ((x) < (y) ? (x) : (y))
+
+#define bpf_printk(fmt, ...)					\
+({								\
+	       char ____fmt[] = fmt;				\
+	       bpf_trace_printk(____fmt, sizeof(____fmt),	\
+				##__VA_ARGS__);			\
+})
+
+/* Metadata will be in the perf event before the packet data. */
+struct S {
+	__u16 cookie;
+	__u16 pkt_len;
+} __packed;
+
+struct bpf_map_def SEC("maps") my_map = {
+	.type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+	.key_size = sizeof(int),
+	.value_size = sizeof(__u32),
+	.max_entries = MAX_CPUS,
+};
+
+SEC("xdp_sample")
+int xdp_sample_prog(struct xdp_md *ctx)
+{
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+
+	if (data < data_end) {
+		/* The XDP perf_event_output handler will use the upper 32 bits
+		 * of the flags argument as a number of bytes to include of the
+		 * packet payload in the event data. If the size is too big, the
+		 * call to bpf_perf_event_output will fail and return -EFAULT.
+		 *
+		 * See bpf_xdp_event_output in net/core/filter.c.
+		 *
+		 * The BPF_F_CURRENT_CPU flag means that the event output fd
+		 * will be indexed by the CPU number in the event map.
+		 */
+		__u64 flags = BPF_F_CURRENT_CPU;
+		__u16 sample_size;
+		int ret;
+		struct S metadata;
+
+		metadata.cookie = 0xdead;
+		metadata.pkt_len = (__u16)(data_end - data);
+		sample_size = min(metadata.pkt_len, SAMPLE_SIZE);
+
+		flags |= (__u64)sample_size << 32;
+
+		ret = bpf_perf_event_output(ctx, &my_map, flags,
+					    &metadata, sizeof(metadata));
+		if (ret)
+			bpf_printk("perf_event_output failed: %d\n", ret);
+	}
+
+	return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/tracing04-xdp-tcpdump/xdp_sample_pkts_user.c
+++ b/tracing04-xdp-tcpdump/xdp_sample_pkts_user.c
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: GPL-2.0
+static const char *__doc__ = "XDP sample packet\n";
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <linux/perf_event.h>
+#include <linux/bpf.h>
+#include <net/if.h>
+#include <errno.h>
+#include <assert.h>
+#include <sys/sysinfo.h>
+#include <sys/ioctl.h>
+#include <signal.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include <sys/resource.h>
+#include <libgen.h>
+#include <linux/if_link.h>
+#include <poll.h>
+#include <sys/mman.h>
+#define PCAP_DONT_INCLUDE_PCAP_BPF_H
+#include <pcap/pcap.h>
+#include <pcap/dlt.h>
+#include "perf-sys.h"
+#include "../common/common_params.h"
+#include "../common/common_user_bpf_xdp.h"
+#include "bpf_util.h"
+#include <time.h>
+
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+
+#define MAX_CPUS 128
+static int pmu_fds[MAX_CPUS];
+static struct perf_event_mmap_page *headers[MAX_CPUS];
+static __u32 prog_id;
+
+static pcap_t* pd;
+static pcap_dumper_t* pdumper;
+static unsigned int pcap_pkts;
+
+static const char *default_filename = "samples.pcap";
+
+static int do_attach(int idx, int fd, const char *name, __u32 xdp_flags)
+{
+	struct bpf_prog_info info = {};
+	__u32 info_len = sizeof(info);
+	int err;
+
+	err = bpf_set_link_xdp_fd(idx, fd, xdp_flags);
+	if (err < 0) {
+		printf("ERROR: failed to attach program to %s\n", name);
+		return err;
+	}
+
+	err = bpf_obj_get_info_by_fd(fd, &info, &info_len);
+	if (err) {
+		printf("can't get prog info - %s\n", strerror(errno));
+		return err;
+	}
+	prog_id = info.id;
+
+	return err;
+}
+
+static int do_detach(int idx, const char *name)
+{
+	__u32 curr_prog_id = 0;
+	int err = 0;
+
+	err = bpf_get_link_xdp_id(idx, &curr_prog_id, 0);
+	if (err) {
+		printf("bpf_get_link_xdp_id failed\n");
+		return err;
+	}
+	if (prog_id == curr_prog_id) {
+		err = bpf_set_link_xdp_fd(idx, -1, 0);
+		if (err < 0)
+			printf("ERROR: failed to detach prog from %s\n", name);
+	} else if (!curr_prog_id) {
+		printf("couldn't find a prog id on a %s\n", name);
+	} else {
+		printf("program on interface changed, not removing\n");
+	}
+
+	return err;
+}
+
+#define SAMPLE_SIZE 1024
+#define NANOSECS_PER_USEC 1000
+
+static int print_bpf_output(void *data, int size)
+{
+	struct {
+		__u16 cookie;
+		__u16 pkt_len;
+		__u8  pkt_data[SAMPLE_SIZE];
+	} __packed *e = data;
+	struct pcap_pkthdr h = {
+		.caplen	= SAMPLE_SIZE,
+		.len	= e->pkt_len,
+	};
+	struct timespec ts;
+	int i, err;
+
+	if (e->cookie != 0xdead) {
+		printf("BUG cookie %x sized %d\n",
+		       e->cookie, size);
+		return LIBBPF_PERF_EVENT_ERROR;
+	}
+
+	err = clock_gettime(CLOCK_MONOTONIC, &ts);
+	if (err < 0) {
+		printf("Error with gettimeofday! (%i)\n", err);
+		return LIBBPF_PERF_EVENT_ERROR;
+	}
+
+	h.ts.tv_sec  = ts.tv_sec;
+	h.ts.tv_usec = ts.tv_nsec / NANOSECS_PER_USEC;
+
+	if (verbose) {
+		printf("pkt len: %-5d bytes. hdr: ", e->pkt_len);
+		for (i = 0; i < e->pkt_len; i++)
+			printf("%02x ", e->pkt_data[i]);
+		printf("\n");
+	}
+
+	pcap_dump((u_char *) pdumper, &h, e->pkt_data);
+	pcap_pkts++;
+	return LIBBPF_PERF_EVENT_CONT;
+}
+
+static void test_bpf_perf_event(int map_fd, int num)
+{
+	struct perf_event_attr attr = {
+		.sample_type	= PERF_SAMPLE_RAW,
+		.type		= PERF_TYPE_SOFTWARE,
+		.config		= PERF_COUNT_SW_BPF_OUTPUT,
+		.wakeup_events	= 1, /* get an fd notification for every event */
+	};
+	int i;
+
+	for (i = 0; i < num; i++) {
+		int key = i;
+
+		pmu_fds[i] = sys_perf_event_open(&attr, -1/*pid*/, i/*cpu*/,
+						 -1/*group_fd*/, 0);
+
+		assert(pmu_fds[i] >= 0);
+		assert(bpf_map_update_elem(map_fd, &key,
+					   &pmu_fds[i], BPF_ANY) == 0);
+		ioctl(pmu_fds[i], PERF_EVENT_IOC_ENABLE, 0);
+	}
+}
+
+static int done;
+
+static void sig_handler(int signo)
+{
+	done = 1;
+}
+
+struct perf_event_sample {
+	struct perf_event_header header;
+	__u32	size;
+	char	data[];
+};
+
+typedef enum bpf_perf_event_ret (*perf_event_print_fn)(void *data, int size);
+
+static enum bpf_perf_event_ret
+bpf_perf_event_print(struct perf_event_header *hdr, void *private_data)
+{
+	struct perf_event_sample *e = (struct perf_event_sample *)hdr;
+	perf_event_print_fn fn = private_data;
+	int ret;
+
+	if (e->header.type == PERF_RECORD_SAMPLE) {
+		ret = fn(e->data, e->size);
+		if (ret != LIBBPF_PERF_EVENT_CONT)
+			return ret;
+	} else if (e->header.type == PERF_RECORD_LOST) {
+		struct {
+			struct perf_event_header header;
+			__u64 id;
+			__u64 lost;
+		} *lost = (void *) e;
+		printf("lost %lld events\n", lost->lost);
+	} else {
+		printf("unknown event type=%d size=%d\n",
+		       e->header.type, e->header.size);
+	}
+
+	return LIBBPF_PERF_EVENT_CONT;
+}
+
+static int page_size;
+static int page_cnt = 8;
+
+int perf_event_mmap_header(int fd, struct perf_event_mmap_page **header)
+{
+	void *base;
+	int mmap_size;
+
+	page_size = getpagesize();
+	mmap_size = page_size * (page_cnt + 1);
+
+	base = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (base == MAP_FAILED) {
+		printf("mmap err\n");
+		return -1;
+	}
+
+	*header = base;
+	return 0;
+}
+
+int perf_event_poller_multi(int *fds, struct perf_event_mmap_page **headers,
+			    int num_fds, perf_event_print_fn output_fn,
+			    int *done)
+{
+	enum bpf_perf_event_ret ret;
+	struct pollfd *pfds;
+	void *buf = NULL;
+	size_t len = 0;
+	int i;
+
+	pfds = calloc(num_fds, sizeof(*pfds));
+	if (!pfds)
+		return LIBBPF_PERF_EVENT_ERROR;
+
+	for (i = 0; i < num_fds; i++) {
+		pfds[i].fd = fds[i];
+		pfds[i].events = POLLIN;
+	}
+
+	while (!*done) {
+		poll(pfds, num_fds, 1000);
+		for (i = 0; i < num_fds; i++) {
+			if (!pfds[i].revents)
+				continue;
+
+			ret = bpf_perf_event_read_simple(headers[i],
+							 page_cnt * page_size,
+							 page_size, &buf, &len,
+							 bpf_perf_event_print,
+							 output_fn);
+			if (ret != LIBBPF_PERF_EVENT_CONT)
+				break;
+		}
+	}
+	free(buf);
+	free(pfds);
+
+	return ret;
+}
+
+static const struct option_wrapper long_options[] = {
+	{{"help",        no_argument,		NULL, 'h' },
+	 "Show help", false},
+
+	{{"force",       no_argument,		NULL, 'F' },
+	 "Force install, replacing existing program on interface"},
+
+	{{"dev",         required_argument,	NULL, 'd' },
+	 "Operate on device <ifname>", "<ifname>", true},
+
+	{{"filename",    required_argument,	NULL,  1  },
+	 "Store packet sample into <file>", "<file>"},
+
+	{{"quiet",       no_argument,		NULL, 'q' },
+	 "Quiet mode (no output)"},
+
+	{{0, 0, NULL,  0 }, NULL, false}
+};
+
+int main(int argc, char **argv)
+{
+	struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
+	struct bpf_prog_load_attr prog_load_attr = {
+		.prog_type	= BPF_PROG_TYPE_XDP,
+	};
+	int prog_fd, map_fd;
+	struct bpf_object *obj;
+	struct bpf_map *map;
+	char filename[256];
+	int ret, err, i;
+	int numcpus = bpf_num_possible_cpus();
+        struct config cfg = {
+                .xdp_flags = XDP_FLAGS_UPDATE_IF_NOEXIST | XDP_FLAGS_DRV_MODE,
+                .ifindex   = -1,
+        };
+
+	strncpy(cfg.filename, default_filename, sizeof(cfg.filename));
+
+        /* Cmdline options can change these */
+        parse_cmdline_args(argc, argv, long_options, &cfg, __doc__);
+
+	/* Required option */
+	if (cfg.ifindex == -1) {
+		fprintf(stderr, "ERR: required option --dev missing\n");
+		usage(argv[0], __doc__, long_options, (argc == 1));
+		return EXIT_FAIL_OPTION;
+	}
+
+	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
+		perror("setrlimit(RLIMIT_MEMLOCK)");
+		return 1;
+	}
+
+	snprintf(filename, sizeof(filename), "xdp_sample_pkts_kern.o");
+	prog_load_attr.file = filename;
+
+	if (bpf_prog_load_xattr(&prog_load_attr, &obj, &prog_fd))
+		return 1;
+
+	if (!prog_fd) {
+		printf("load_bpf_file: %s\n", strerror(errno));
+		return 1;
+	}
+
+	map = bpf_map__next(NULL, obj);
+	if (!map) {
+		printf("finding a map in obj file failed\n");
+		return 1;
+	}
+	map_fd = bpf_map__fd(map);
+
+	err = do_attach(cfg.ifindex, prog_fd, cfg.ifname, cfg.xdp_flags);
+	if (err)
+		return err;
+
+	if (signal(SIGINT, sig_handler) ||
+	    signal(SIGHUP, sig_handler) ||
+	    signal(SIGTERM, sig_handler)) {
+		perror("signal");
+		return 1;
+	}
+
+	test_bpf_perf_event(map_fd, numcpus);
+
+	for (i = 0; i < numcpus; i++)
+		if (perf_event_mmap_header(pmu_fds[i], &headers[i]) < 0)
+			return 1;
+
+	pd = pcap_open_dead(DLT_EN10MB, 65535);
+	if (!pd)
+		goto out;
+
+	pdumper = pcap_dump_open(pd, cfg.filename);
+	if (!pdumper)
+		goto out;
+
+	ret = perf_event_poller_multi(pmu_fds, headers, numcpus,
+				      print_bpf_output, &done);
+
+	pcap_dump_close(pdumper);
+	pcap_close(pd);
+
+out:
+	do_detach(cfg.ifindex, cfg.ifname);
+	printf("\n%u packet samples stored in %s\n", pcap_pkts, cfg.filename);
+	return ret;
+}


### PR DESCRIPTION
Adding following trace examples/directories:
  tracing01-xdp-simple
  tracing02-xdp-monitor
  tracing03-xdp-debug-print
  tracing04-xdp-tcpdump

as introduction to tracepoint and perf related monitoring/debuging.