### PR TITLE
Fix stats_print in basic03 and basic04

### DIFF
--- a/basic03-map-counter/xdp_load_and_stats.c
+++ b/basic03-map-counter/xdp_load_and_stats.c
@@ -136,7 +136,7 @@ static void stats_print(struct stats_record *stats_rec,
 		packets = rec->total.rx_packets - prev->total.rx_packets;
 		pps     = packets / period;
 
-		printf(fmt, action, rec->total.rx_packets, pps, period);
+		printf(fmt, action, packets, pps, period);
 	}
 }
 

--- a/basic04-pinning-maps/xdp_stats.c
+++ b/basic04-pinning-maps/xdp_stats.c
@@ -112,8 +112,8 @@ static void stats_print(struct stats_record *stats_rec,
 		bytes   = rec->total.rx_bytes   - prev->total.rx_bytes;
 		bps     = (bytes * 8)/ period / 1000000;
 
-		printf(fmt, action, rec->total.rx_packets, pps,
-		       rec->total.rx_bytes / 1000 , bps,
+		printf(fmt, action, packets, pps,
+		       bytes / 1000 , bps,
 		       period);
 	}
 	printf("\n");


### PR DESCRIPTION
stats_print currently uses `rec->total.rx_packets` which prints the total packets received since the program was launched, but it should be printing `packets` which is the number of packets received this interval.