### PR TITLE
Tracing some simple fixes

### DIFF
--- a/tracing01-xdp-simple/Makefile
+++ b/tracing01-xdp-simple/Makefile
@@ -4,6 +4,8 @@
 XDP_TARGETS  := trace_prog_kern xdp_prog_kern
 USER_TARGETS := trace_load_and_stats
 
+COPY_LOADER = xdp_loader
+
 LIBBPF_DIR = ../libbpf/src/
 COMMON_DIR = ../common/
 

--- a/tracing01-xdp-simple/README.org
+++ b/tracing01-xdp-simple/README.org
@@ -7,21 +7,20 @@ hooks on xdp:exception tracepoint and get its values to user space
 stats application.
 
 * Table of Contents                                                     :TOC:
-- [[#using-libbpf][XDP tracepoints]]
-  - [[#xdp-tracepoints][XDP tracepoints]]
+- [[#xdp-tracepoints][XDP tracepoints]]
   - [[#tracepoint-program-section][Tracepoint program section]]
   - [[#tracepoint-arguments][Tracepoint arguments]]
   - [[#tracepoint-attaching][Tracepoint attaching]]
   - [[#hash-map][HASH map]]
 - [[#assignments][Assignments]]
-  - [[#assignment-1][Assignment 1: Setting up your test lab]]
-  - [[#assignment-2][Assignment 2: Load tracepoint monitor program]]
+  - [[#assignment-1-setting-up-your-test-lab][Assignment 1: Setting up your test lab]]
+  - [[#assignment-2-load-tracepoint-monitor-program][Assignment 2: Load tracepoint monitor program]]
 
 
 * XDP tracepoints
 
 The eBPF programs can be attached also to tracepoints. There are
-several tracepoints related to xdp:
+several tracepoints related to the xdp tracepoint subsystem:
 
 #+begin_example sh
 ls /sys/kernel/debug/tracing/events/xdp/
@@ -41,13 +40,11 @@ The bpf library expects the tracepoint eBPF program to be stored
 in a section with following name:
 
 #+begin_example sh
-tracepoint/sys/tracepoint
+tracepoint/<sys>/<tracepoint>
 #+end_example
 
-where 'sys' is the tracepoint subsystem and 'tracepoint' is
-the tracepoint name.
-
-which can be done with following construct:
+where =<sys>= is the tracepoint subsystem and =<tracepoint>= is
+the tracepoint name, which can be done with following construct:
 
 #+begin_example sh
 SEC("tracepoint/xdp/xdp_exception")

--- a/tracing01-xdp-simple/README.org
+++ b/tracing01-xdp-simple/README.org
@@ -171,7 +171,7 @@ $ sudo ../testenv/testenv.sh setup --name veth-basic02
 Load the XDP program, tak produces aborted packets:
 
 #+begin_example sh
-$ sudo ../basic02-prog-by-name/xdp_loader --dev veth-basic02 --force --progsec xdp_abort
+$ sudo ./xdp_loader --dev veth-basic02 --force --progsec xdp_abort
 #+end_example
 
 and make some packets:

--- a/tracing02-xdp-monitor/README.org
+++ b/tracing02-xdp-monitor/README.org
@@ -7,10 +7,9 @@ xdp related raw tracepoints and some related info to user space
 stat application.
 
 * Table of Contents                                                     :TOC:
-- [[#raw-tracepoint][RAW tracepoints]]
-  - [[#todo][TODO]]
+- [[#raw-tracepoints][RAW tracepoints]]
 - [[#assignments][Assignments]]
-  - [[#assignment-1][Assignment 1: Monitor all xdp tracepoints]]
+  - [[#assignment-1-monitor-all-xdp-tracepoints][Assignment 1: Monitor all xdp tracepoints]]
 
 * RAW tracepoints
 
@@ -22,10 +21,10 @@ The bpf library expects the raw tracepoint eBPF program to be stored
 in a section with following name:
 
 #+begin_example sh
-raw_tracepoint/tracepoint/sys/tracepoint
+raw_tracepoint/<sys>/<tracepoint>
 #+end_example
 
-where 'sys' is the tracepoint subsystem and 'tracepoint' is
+where =<sys>= is the tracepoint subsystem and =<tracepoint>= is
 the tracepoint name, which can be done with following construct:
 
 #+begin_example sh
@@ -34,7 +33,7 @@ int trace_xdp_exception(struct xdp_exception_ctx *ctx)
 #+end_example
 
 The libbpf library exports interface to load and attach raw tracepoint
-programs, following call will load every program in the cfg->filename
+programs, following call will load every program in the =cfg->filename=
 object as raw tracepoint programs:
 
 #+begin_example sh

--- a/tracing03-xdp-debug-print/Makefile
+++ b/tracing03-xdp-debug-print/Makefile
@@ -3,6 +3,8 @@
 XDP_TARGETS := xdp_prog_kern
 USER_TARGETS := trace_read
 
+COPY_LOADER = xdp_loader
+
 LLC ?= llc
 CLANG ?= clang
 CC := gcc

--- a/tracing03-xdp-debug-print/README.org
+++ b/tracing03-xdp-debug-print/README.org
@@ -90,7 +90,7 @@ Load XDP program from xdp_prog_kern.o that will print
 ethertnet header on every incoming packet:
 
 #+begin_example sh
-$ sudo ../basic02-prog-by-name/xdp_loader --dev veth-basic02 --force --progsec xdp
+$ sudo ./xdp_loader --dev veth-basic02 --force --progsec xdp
 #+end_example
 
 and make some packets:

--- a/tracing03-xdp-debug-print/README.org
+++ b/tracing03-xdp-debug-print/README.org
@@ -6,11 +6,11 @@ In this lesson we will show how to print message from eBPF program
 into tracefs buffer.
 
 * Table of Contents                                                     :TOC:
-- [[#bpf-trace-printk][eBPF trace printk helper]]
-- [[#tracefs-pipe-reader][The tracefs pipe reader]]
+- [[#ebpf-trace-printk-helper][eBPF trace printk helper]]
+- [[#the-tracefs-pipe-reader][The tracefs pipe reader]]
 - [[#assignments][Assignments]]
   - [[#assignment-1-setting-up-your-test-lab][Assignment 1: Setting up your test lab]]
-  - [[#assignment-2-bpf-trace-printk][Assignment 2: Run debug code]]
+  - [[#assignment-2-run-debug-code][Assignment 2: Run debug code]]
 
 
 * eBPF trace printk helper
@@ -101,7 +101,7 @@ $ sudo ../testenv/testenv.sh enter --name veth-basic02
 PING fc00:dead:cafe:1::1(fc00:dead:cafe:1::1) 56 data bytes
 #+end_example
 
-- Assignment 2: Run debug code
+** Assignment 2: Run debug code
 
 #+begin_example sh
 bpf_printk("src: %llu, dst: %llu, proto: %u\n",

--- a/tracing04-xdp-tcpdump/README.org
+++ b/tracing04-xdp-tcpdump/README.org
@@ -9,8 +9,8 @@ from XDP program all the way to the pcap dump file.
 * Table of Contents                                                     :TOC:
 - [[#dump-the-packet-sample][Dump the packet sample]]
 - [[#assignments][Assignments]]
-  - [[#assignment-1-setup][Assignment 1: Setting up your test lab]]
-  - [[#assignment-2-pcap-dump][Assignment 2: The PCAP dump file]]
+  - [[#assignment-1-setting-up-your-test-lab][Assignment 1: Setting up your test lab]]
+  - [[#assignment-2-the-pcap-dump-file][Assignment 2: The PCAP dump file]]
 
 * Dump the packet sample
 

--- a/tracing04-xdp-tcpdump/README.org
+++ b/tracing04-xdp-tcpdump/README.org
@@ -100,7 +100,9 @@ PING fc00:dead:cafe:1::1(fc00:dead:cafe:1::1) 56 data bytes
 
 ** Assignment 2: The PCAP dump file
 
-Load the eBPF kernel packets dump program and store the packets to the dump file:
+Build the =xdp_sample_pkts_user= dump program; to do so you might have to
+install the =libpcap-dev= and the 32 bit libc dev packages.  Load the eBPF
+kernel packets dump program and store the packets to the dump file:
 
 #+begin_example sh
 $ sudo ./xdp_sample_pkts_user -d veth-basic02 -F


### PR DESCRIPTION
Fix several typos and broken links in tracing* lessons. Copy loader using the "standard" XDP_LOADER variable in tracing* lessons which use it.