### PR TITLE
Fix location of help(-h) option parsing.

### DIFF
--- a/common/common_params.c
+++ b/common/common_params.c
@@ -156,9 +156,6 @@ void parse_cmdline_args(int argc, char **argv,
 			dest  = (char *)&cfg->progsec;
 			strncpy(dest, optarg, sizeof(cfg->progsec));
 			break;
-		case 'h':
-			full_help = true;
-			/* fall-through */
 		case 'L': /* --src-mac */
 			dest  = (char *)&cfg->src_mac;
 			strncpy(dest, optarg, sizeof(cfg->src_mac));
@@ -167,6 +164,9 @@ void parse_cmdline_args(int argc, char **argv,
 			dest  = (char *)&cfg->dest_mac;
 			strncpy(dest, optarg, sizeof(cfg->dest_mac));
 			break;
+		case 'h':
+			full_help = true;
+			/* fall-through */
 		error:
 		default:
 			usage(argv[0], doc, options_wrapper, full_help);


### PR DESCRIPTION
When running examples only using -h as an arguments it segfaults as it also tries to parse other, non-existing opts.