### PR TITLE
Tutorial: investigate compiler optimizations

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -68,7 +68,7 @@ $(COPY_STATS): $(LOADER_DIR)/${COPY_STATS:=.c} $(COMMON_H)
 	make -C $(LOADER_DIR) $(COPY_STATS)
 	cp $(LOADER_DIR)/$(COPY_STATS) $(COPY_STATS)
 # Needing xdp_stats imply depending on header files:
-EXTRA_DEPS := $(COMMON_DIR)/xdp_stats_kern.h $(COMMON_DIR)/xdp_stats_kern_user.h
+EXTRA_DEPS += $(COMMON_DIR)/xdp_stats_kern.h $(COMMON_DIR)/xdp_stats_kern_user.h
 endif
 
 # For build dependency on this file, if it gets updated

--- a/common/parsing_helpers.h
+++ b/common/parsing_helpers.h
@@ -54,7 +54,10 @@ struct icmphdr_common {
 	__sum16		cksum;
 };
 
-#define VLAN_MAX_DEPTH 5
+/* Allow users of header file to redefine VLAN max depth */
+#ifndef VLAN_MAX_DEPTH
+#define VLAN_MAX_DEPTH 2
+#endif
 
 static __always_inline int proto_is_vlan(__u16 h_proto)
 {

--- a/common/parsing_helpers.h
+++ b/common/parsing_helpers.h
@@ -62,6 +62,11 @@ static __always_inline int proto_is_vlan(__u16 h_proto)
                   h_proto == bpf_htons(ETH_P_8021AD));
 }
 
+/* Notice, parse_ethhdr() will skip VLAN tags, by advancing nh->pos and returns
+ * next header EtherType, BUT the ethhdr pointer supplied still points to the
+ * Ethernet header. Thus, caller can look at eth->h_proto to see if this was a
+ * VLAN tagged packet.
+ */
 static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
 					struct ethhdr **ethhdr)
 {

--- a/common/parsing_helpers.h
+++ b/common/parsing_helpers.h
@@ -56,7 +56,7 @@ struct icmphdr_common {
 
 /* Allow users of header file to redefine VLAN max depth */
 #ifndef VLAN_MAX_DEPTH
-#define VLAN_MAX_DEPTH 2
+#define VLAN_MAX_DEPTH 4
 #endif
 
 static __always_inline int proto_is_vlan(__u16 h_proto)

--- a/packet-solutions/Makefile
+++ b/packet-solutions/Makefile
@@ -8,6 +8,6 @@ COMMON_DIR = ../common
 
 COPY_LOADER := xdp_loader
 COPY_STATS  := xdp_stats
-EXTRA_DEPS := $(COMMON_DIR)/parsing_helpers.h
+EXTRA_DEPS  += $(COMMON_DIR)/parsing_helpers.h
 
 include $(COMMON_DIR)/common.mk

--- a/packet-solutions/Makefile
+++ b/packet-solutions/Makefile
@@ -2,6 +2,7 @@
 
 XDP_TARGETS  := xdp_prog_kern_02 xdp_prog_kern_03
 XDP_TARGETS  += xdp_vlan01_kern
+XDP_TARGETS  += xdp_vlan02_kern
 USER_TARGETS := xdp_prog_user
 
 LIBBPF_DIR = ../libbpf/src/

--- a/packet-solutions/Makefile
+++ b/packet-solutions/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
 XDP_TARGETS  := xdp_prog_kern_02 xdp_prog_kern_03
+XDP_TARGETS  += xdp_vlan01_kern
 USER_TARGETS := xdp_prog_user
 
 LIBBPF_DIR = ../libbpf/src/

--- a/packet-solutions/xdp_prog_kern_02.c
+++ b/packet-solutions/xdp_prog_kern_02.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 #include <linux/bpf.h>
 #include <linux/in.h>
+
+#include <linux/if_ether.h>
 #include "bpf_helpers.h"
 #include "bpf_endian.h"
 

--- a/packet-solutions/xdp_vlan01_kern.c
+++ b/packet-solutions/xdp_vlan01_kern.c
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+
+#include "bpf_helpers.h"
+#include "bpf_endian.h"
+
+/* NOTICE: Re-defining VLAN header levels to parse */
+#define VLAN_MAX_DEPTH 10
+//#include "../common/parsing_helpers.h"
+/*
+ * NOTICE: Copied over parts of ../common/parsing_helpers.h
+ *         to make it easier to point out compiler optimizations
+ */
+
+/* Header cursor to keep track of current parsing position */
+struct hdr_cursor {
+	void *pos;
+};
+
+static __always_inline int proto_is_vlan(__u16 h_proto)
+{
+        return !!(h_proto == bpf_htons(ETH_P_8021Q) ||
+                  h_proto == bpf_htons(ETH_P_8021AD));
+}
+
+/*
+ * 	struct vlan_hdr - vlan header
+ * 	@h_vlan_TCI: priority and VLAN ID
+ *	@h_vlan_encapsulated_proto: packet type ID or len
+ */
+struct vlan_hdr {
+	__be16	h_vlan_TCI;
+	__be16	h_vlan_encapsulated_proto; /* NOTICE: unsigned type */
+};
+
+/* Notice, parse_ethhdr() will skip VLAN tags, by advancing nh->pos and returns
+ * next header EtherType, BUT the ethhdr pointer supplied still points to the
+ * Ethernet header. Thus, caller can look at eth->h_proto to see if this was a
+ * VLAN tagged packet.
+ */
+static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
+					struct ethhdr **ethhdr)
+{
+	struct ethhdr *eth = nh->pos;
+	int hdrsize = sizeof(*eth);
+        struct vlan_hdr *vlh;
+        __u16 h_proto;
+        int i;
+
+	/* Byte-count bounds check; check if current pointer + size of header
+	 * is after data_end.
+	 */
+	if (nh->pos + hdrsize > data_end)
+		return -1;
+
+	nh->pos += hdrsize;
+	*ethhdr = eth;
+        vlh = nh->pos;
+        h_proto = eth->h_proto;
+
+        /* Use loop unrolling to avoid the verifier restriction on loops;
+         * support up to VLAN_MAX_DEPTH layers of VLAN encapsulation.
+         */
+        #pragma unroll
+        for (i = 0; i < VLAN_MAX_DEPTH; i++) {
+                if (!proto_is_vlan(h_proto))
+                        break;
+
+                if (vlh + 1 > data_end)
+                        break;
+
+                h_proto = vlh->h_vlan_encapsulated_proto;
+                vlh++;
+        }
+
+        nh->pos = vlh;
+	return bpf_ntohs(h_proto);
+}
+
+SEC("xdp_vlan01")
+int xdp_vlan_01(struct xdp_md *ctx)
+{
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+
+	/* These keep track of the next header type and iterator pointer */
+	struct hdr_cursor nh;
+	int nh_type;
+	nh.pos = data;
+
+	struct ethhdr *eth;
+	nh_type = parse_ethhdr(&nh, data_end, &eth);
+	if (nh_type < 0)
+		return XDP_ABORTED;
+
+	/* The LLVM compiler is very clever, and will remove above walking of
+	 * VLAN headers (the loop unroll).
+	 *
+	 * The returned value nh_type, variable (__u16) h_proto in
+	 * parse_ethhdr(), is only compared against a negative value (signed).
+	 * The compile see that it can remove the VLAN loop, because:
+	 *  1. h_proto = vlh->h_vlan_encapsulated_proto can only be >= 0
+	 *  2. we never read nh->pos (so it removes nh->pos = vlh;).
+	 */
+
+	/* Accessing eth pointer is still valid after compiler optimization */
+	if (proto_is_vlan(eth->h_proto))
+		return XDP_DROP;
+
+	/* Hint: to inspect BPF byte-code run:
+	 *  llvm-objdump -S xdp_vlan01_kern.o
+	 */
+	return XDP_PASS;
+}

--- a/packet-solutions/xdp_vlan02_kern.c
+++ b/packet-solutions/xdp_vlan02_kern.c
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/in.h>
+
+#include "bpf_helpers.h"
+#include "bpf_endian.h"
+
+/* NOTICE: Re-defining VLAN header levels to parse */
+#define VLAN_MAX_DEPTH 10
+#include "../common/parsing_helpers.h"
+
+#define VLAN_VID_MASK		0x0fff /* VLAN Identifier */
+struct vlans {
+	__u16 id[VLAN_MAX_DEPTH];
+};
+
+/* Based on parse_ethhdr() */
+static __always_inline int __parse_ethhdr_vlan(struct hdr_cursor *nh,
+					       void *data_end,
+					       struct ethhdr **ethhdr,
+					       struct vlans* vlans)
+{
+	struct ethhdr *eth = nh->pos;
+	int hdrsize = sizeof(*eth);
+        struct vlan_hdr *vlh;
+        __u16 h_proto;
+        int i;
+
+	/* Byte-count bounds check; check if current pointer + size of header
+	 * is after data_end.
+	 */
+	if (nh->pos + hdrsize > data_end)
+		return -1;
+
+	nh->pos += hdrsize;
+	*ethhdr = eth;
+        vlh = nh->pos;
+        h_proto = eth->h_proto;
+
+        /* Use loop unrolling to avoid the verifier restriction on loops;
+         * support up to VLAN_MAX_DEPTH layers of VLAN encapsulation.
+         */
+        #pragma unroll
+        for (i = 0; i < VLAN_MAX_DEPTH; i++) {
+                if (!proto_is_vlan(h_proto))
+                        break;
+
+                if (vlh + 1 > data_end)
+                        break;
+
+                h_proto = vlh->h_vlan_encapsulated_proto;
+		if (vlans) {
+			vlans->id[i] =  vlh->h_vlan_TCI & VLAN_VID_MASK;
+		}
+                vlh++;
+        }
+
+        nh->pos = vlh;
+	return bpf_ntohs(h_proto);
+}
+
+SEC("xdp_vlan02")
+int xdp_vlan_02(struct xdp_md *ctx)
+{
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+
+	/* These keep track of the next header type and iterator pointer */
+	struct hdr_cursor nh;
+	int eth_type;
+	nh.pos = data;
+
+	struct vlans vlans;
+
+	struct ethhdr *eth;
+	eth_type = __parse_ethhdr_vlan(&nh, data_end, &eth, &vlans);
+
+	if (eth_type < 0)
+		return XDP_ABORTED;
+
+	/* The LLVM compiler is very clever, it sees that program only access
+	 * 2nd "inner" vlan (array index 1), and only does loop unroll of 2, and
+	 * only does the VLAN_VID_MASK in the 2nd "inner" vlan case.
+	 */
+	if (vlans.id[1] == 42)
+		return XDP_ABORTED;
+
+	/* If using eth_type (even compare against zero), it will cause full
+	 * loop unroll and walking all VLANs (for VLAN_MAX_DEPTH). Still only
+	 * "inner" VLAN is masked out.
+	 */
+#if 0
+	if (eth_type == 0)
+		return XDP_PASS;
+#endif
+
+	/* Unless we only want to manipulate VLAN, then next step will naturally
+	 * be parsing the next L3 headers. This (also) cause compiler to create
+	 * VLAN loop, as this uses nh->pos
+	 */
+#if 0
+	int ip_type;
+	struct iphdr *iphdr;
+	if (eth_type == ETH_P_IP) {
+		ip_type = parse_iphdr(&nh, data_end, &iphdr);
+		if (eth_type < 0)
+			return XDP_ABORTED;
+
+		if (ip_type == IPPROTO_UDP)
+			return XDP_DROP;
+	}
+#endif
+	/* Hint: to inspect BPF byte-code run:
+	 *  llvm-objdump -S xdp_vlan02_kern.o
+	 */
+	return XDP_PASS;
+}


### PR DESCRIPTION
This branch turned into an investigation into LLVM compiler optimizations effect on ```parse_ethhdr()```.

As described in issue #59 I was going to improve [common/parsing_helpers.h](https://github.com/xdp-project/xdp-tutorial/blob/master/common/parsing_helpers.h) specifically ```parse_ethhdr()``` instead I was surprised how clever the LLVM compiler were.  I have check that the compiler optimizations were correct...

I'll create a new branch where I'll do what I originally planned (see #59).