### PR TITLE
Change parse_ethhdr() to return network-byte-order

### DIFF
--- a/common/parsing_helpers.h
+++ b/common/parsing_helpers.h
@@ -106,7 +106,7 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
 	}
 
 	nh->pos = vlh;
-	return bpf_ntohs(h_proto);
+	return h_proto; /* network-byte-order */
 }
 
 static __always_inline int parse_ip6hdr(struct hdr_cursor *nh,

--- a/packet-solutions/xdp_prog_kern_02.c
+++ b/packet-solutions/xdp_prog_kern_02.c
@@ -37,9 +37,9 @@ int xdp_patch_ports_func(struct xdp_md *ctx)
 		goto out;
 	}
 
-	if (eth_type == ETH_P_IP) {
+	if (eth_type == bpf_htons(ETH_P_IP)) {
 		ip_type = parse_iphdr(&nh, data_end, &iphdr);
-	} else if (eth_type == ETH_P_IPV6) {
+	} else if (eth_type == bpf_htons(ETH_P_IPV6)) {
 		ip_type = parse_ip6hdr(&nh, data_end, &ipv6hdr);
 	} else {
 		goto out;

--- a/packet-solutions/xdp_prog_kern_03.c
+++ b/packet-solutions/xdp_prog_kern_03.c
@@ -76,11 +76,11 @@ int xdp_icmp_echo_func(struct xdp_md *ctx)
 
 	/* Parse Ethernet and IP/IPv6 headers */
 	eth_type = parse_ethhdr(&nh, data_end, &eth);
-	if (eth_type == ETH_P_IP) {
+	if (eth_type == bpf_htons(ETH_P_IP)) {
 		ip_type = parse_iphdr(&nh, data_end, &iphdr);
 		if (ip_type != IPPROTO_ICMP)
 			goto out;
-	} else if (eth_type == ETH_P_IPV6) {
+	} else if (eth_type == bpf_htons(ETH_P_IPV6)) {
 		ip_type = parse_ip6hdr(&nh, data_end, &ipv6hdr);
 		if (ip_type != IPPROTO_ICMPV6)
 			goto out;
@@ -95,11 +95,12 @@ int xdp_icmp_echo_func(struct xdp_md *ctx)
 	 * the rest of the structure.
 	 */
 	icmp_type = parse_icmphdr_common(&nh, data_end, &icmphdr);
-	if (eth_type == ETH_P_IP && icmp_type == ICMP_ECHO) {
+	if (eth_type == bpf_htons(ETH_P_IP) && icmp_type == ICMP_ECHO) {
 		/* Swap IP source and destination */
 		swap_src_dst_ipv4(iphdr);
 		echo_reply = ICMP_ECHOREPLY;
-	} else if (eth_type == ETH_P_IPV6 && icmp_type == ICMPV6_ECHO_REQUEST) {
+	} else if (eth_type == bpf_htons(ETH_P_IPV6)
+		   && icmp_type == ICMPV6_ECHO_REQUEST) {
 		/* Swap IPv6 source and destination */
 		swap_src_dst_ipv6(ipv6hdr);
 		echo_reply = ICMPV6_ECHO_REPLY;

--- a/packet-solutions/xdp_vlan01_kern.c
+++ b/packet-solutions/xdp_vlan01_kern.c
@@ -75,7 +75,7 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
 	}
 
 	nh->pos = vlh;
-	return bpf_ntohs(h_proto);
+	return h_proto; /* network-byte-order */
 }
 
 SEC("xdp_vlan01")

--- a/packet-solutions/xdp_vlan02_kern.c
+++ b/packet-solutions/xdp_vlan02_kern.c
@@ -57,7 +57,7 @@ static __always_inline int __parse_ethhdr_vlan(struct hdr_cursor *nh,
 	}
 
 	nh->pos = vlh;
-	return bpf_ntohs(h_proto);
+	return h_proto; /* network-byte-order */
 }
 
 SEC("xdp_vlan02")
@@ -102,7 +102,7 @@ int xdp_vlan_02(struct xdp_md *ctx)
 #if 0
 	int ip_type;
 	struct iphdr *iphdr;
-	if (eth_type == ETH_P_IP) {
+	if (eth_type == bpf_htons(ETH_P_IP)) {
 		ip_type = parse_iphdr(&nh, data_end, &iphdr);
 		if (eth_type < 0)
 			return XDP_ABORTED;

--- a/packet01-parsing/xdp_prog_kern.c
+++ b/packet01-parsing/xdp_prog_kern.c
@@ -42,7 +42,7 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh,
 	nh->pos += hdrsize;
 	*ethhdr = eth;
 
-	return bpf_ntohs(eth->h_proto);
+	return eth->h_proto; /* network-byte-order */
 }
 
 /* Assignment 2: Implement and use this */
@@ -84,7 +84,7 @@ int  xdp_parser_func(struct xdp_md *ctx)
 	 * header type in the packet correct?), and bounds checking.
 	 */
 	nh_type = parse_ethhdr(&nh, data_end, &eth);
-	if (nh_type != ETH_P_IPV6)
+	if (nh_type != bpf_htons(ETH_P_IPV6))
 		goto out;
 
 	/* Assignment additions go below here */

--- a/packet02-rewriting/xdp_prog_kern.c
+++ b/packet02-rewriting/xdp_prog_kern.c
@@ -116,7 +116,7 @@ int  xdp_parser_func(struct xdp_md *ctx)
 	 */
 	nh_type = parse_ethhdr(&nh, data_end, &eth);
 
-	if (nh_type == ETH_P_IPV6) {
+	if (nh_type == bpf_htons(ETH_P_IPV6)) {
 		struct ipv6hdr *ip6h;
 		struct icmp6hdr *icmp6h;
 
@@ -131,7 +131,7 @@ int  xdp_parser_func(struct xdp_md *ctx)
 		if (bpf_ntohs(icmp6h->icmp6_sequence) % 2 == 0)
 			action = XDP_DROP;
 
-	} else if (nh_type == ETH_P_IP) {
+	} else if (nh_type == bpf_htons(ETH_P_IP)) {
 		struct iphdr *iph;
 		struct icmphdr *icmph;
 

--- a/packet03-redirecting/xdp_prog_kern.c
+++ b/packet03-redirecting/xdp_prog_kern.c
@@ -66,11 +66,11 @@ int xdp_icmp_echo_func(struct xdp_md *ctx)
 
 	/* Parse Ethernet and IP/IPv6 headers */
 	eth_type = parse_ethhdr(&nh, data_end, &eth);
-	if (eth_type == ETH_P_IP) {
+	if (eth_type == bpf_htons(ETH_P_IP)) {
 		ip_type = parse_iphdr(&nh, data_end, &iphdr);
 		if (ip_type != IPPROTO_ICMP)
 			goto out;
-	} else if (eth_type == ETH_P_IPV6) {
+	} else if (eth_type == bpf_htons(ETH_P_IPV6)) {
 		ip_type = parse_ip6hdr(&nh, data_end, &ipv6hdr);
 		if (ip_type != IPPROTO_ICMPV6)
 			goto out;
@@ -85,11 +85,12 @@ int xdp_icmp_echo_func(struct xdp_md *ctx)
 	 * the rest of the structure.
 	 */
 	icmp_type = parse_icmphdr_common(&nh, data_end, &icmphdr);
-	if (eth_type == ETH_P_IP && icmp_type == ICMP_ECHO) {
+	if (eth_type == bpf_htons(ETH_P_IP) && icmp_type == ICMP_ECHO) {
 		/* Swap IP source and destination */
 		swap_src_dst_ipv4(iphdr);
 		echo_reply = ICMP_ECHOREPLY;
-	} else if (eth_type == ETH_P_IPV6 && icmp_type == ICMPV6_ECHO_REQUEST) {
+	} else if (eth_type == bpf_htons(ETH_P_IPV6)
+		   && icmp_type == ICMPV6_ECHO_REQUEST) {
 		/* Swap IPv6 source and destination */
 		swap_src_dst_ipv6(ipv6hdr);
 		echo_reply = ICMPV6_ECHO_REPLY;


### PR DESCRIPTION
Raised as issue #59.

One advantage of not using bpf_ntohs() call on packet data (eth->h_proto) is that users of the API can instead do compares against constants e.g. VLAN check bpf_htons(ETH_P_8021Q), which will allow compiler to do this compile time (instead of runtime).

I guess someone else need to review my changes... as all users of parse_ethhdr() need to do the correct conversion now.