### PR TITLE
More examples to access XDP packet data at packet end 

### DIFF
--- a/experiment01-tailgrow/Makefile
+++ b/experiment01-tailgrow/Makefile
@@ -2,6 +2,7 @@
 
 XDP_TARGETS  := xdp_prog_kern xdp_prog_kern2
 XDP_TARGETS  += xdp_prog_kern3
+XDP_TARGETS  += xdp_prog_kern4
 XDP_TARGETS  += xdp_prog_fail1
 XDP_TARGETS  += xdp_prog_fail2
 

--- a/experiment01-tailgrow/Makefile
+++ b/experiment01-tailgrow/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
 XDP_TARGETS  := xdp_prog_kern xdp_prog_kern2
+XDP_TARGETS  += xdp_prog_kern3
 XDP_TARGETS  += xdp_prog_fail1
 XDP_TARGETS  += xdp_prog_fail2
 

--- a/experiment01-tailgrow/xdp_data_access_helpers.h
+++ b/experiment01-tailgrow/xdp_data_access_helpers.h
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2020 Authors of Cilium
+ *
+ * Code copied from cilium/bpf/include/bpf/ctx/xdp.h
+ *  https://github.com/cilium/cilium/blob/master/bpf/include/bpf/ctx/xdp.h
+ */
+
+#ifndef _XDP_DATA_ACCESS_HELPERS_H_
+#define _XDP_DATA_ACCESS_HELPERS_H_
+
+/* This must be a mask and all offsets guaranteed to be less than that. */
+//#define __CTX_OFF_MAX			0xff
+#define __CTX_OFF_MAX			0x1fff
+
+#ifndef __maybe_unused
+# define __maybe_unused		__attribute__((__unused__))
+#endif
+
+#ifndef EINVAL
+# define EINVAL	22
+#endif
+
+#ifndef memcpy
+# define memcpy(dest, src, n)   __builtin_memcpy((dest), (src), (n))
+#endif
+
+static __always_inline __maybe_unused int
+xdp_load_bytes(struct xdp_md *ctx, __u64 off, void *to, const __u64 len)
+{
+	void *from;
+	int ret;
+	/* LLVM tends to generate code that verifier doesn't understand,
+	 * so force it the way we want it in order to open up a range
+	 * on the reg.
+	 */
+	asm volatile("r1 = *(u32 *)(%[ctx] +0)\n\t"
+		     "r2 = *(u32 *)(%[ctx] +4)\n\t"
+		     "%[off] &= %[offmax]\n\t"
+		     "r1 += %[off]\n\t"
+		     "%[from] = r1\n\t"
+		     "r1 += %[len]\n\t"
+		     "if r1 > r2 goto +2\n\t"
+		     "%[ret] = 0\n\t"
+		     "goto +1\n\t"
+		     "%[ret] = %[errno]\n\t"
+		     : [ret]"=r"(ret), [from]"=r"(from)
+		     : [ctx]"r"(ctx), [off]"r"(off), [len]"ri"(len),
+		       [offmax]"i"(__CTX_OFF_MAX), [errno]"i"(-EINVAL)
+		     : "r1", "r2");
+	if (!ret)
+		memcpy(to, from, len);
+	return ret;
+}
+
+static __always_inline __maybe_unused int
+xdp_store_bytes(struct xdp_md *ctx, __u64 off, const void *from,
+		const __u64 len, __u64 flags __maybe_unused)
+{
+	void *to;
+	int ret;
+	/* See xdp_load_bytes(). */
+	asm volatile("r1 = *(u32 *)(%[ctx] +0)\n\t"
+		     "r2 = *(u32 *)(%[ctx] +4)\n\t"
+		     "%[off] &= %[offmax]\n\t"
+		     "r1 += %[off]\n\t"
+		     "%[to] = r1\n\t"
+		     "r1 += %[len]\n\t"
+		     "if r1 > r2 goto +2\n\t"
+		     "%[ret] = 0\n\t"
+		     "goto +1\n\t"
+		     "%[ret] = %[errno]\n\t"
+		     : [ret]"=r"(ret), [to]"=r"(to)
+		     : [ctx]"r"(ctx), [off]"r"(off), [len]"ri"(len),
+		       [offmax]"i"(__CTX_OFF_MAX), [errno]"i"(-EINVAL)
+		     : "r1", "r2");
+	if (!ret)
+		memcpy(to, from, len);
+	return ret;
+}
+
+#define ctx_load_bytes			xdp_load_bytes
+#define ctx_store_bytes			xdp_store_bytes
+
+#endif /* _XDP_DATA_ACCESS_HELPERS_H_ */

--- a/experiment01-tailgrow/xdp_prog_kern3.c
+++ b/experiment01-tailgrow/xdp_prog_kern3.c
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+/*
+ * This BPF-prog will FAIL, due to verifier rejecting it.
+ *
+ * General idea: Use packet length to find and access last byte in
+ * packet.  The verifier cannot see this is safe, as it cannot deduce
+ * the packet length at verification time.
+ */
+
+SEC("xdp_fail1")
+int _xdp_fail1(struct xdp_md *ctx)
+{
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+	unsigned char *ptr;
+	void *pos;
+
+	/* (Correct me if I'm wrong)
+	 *
+	 * The verifier cannot use this packet length calculation as
+	 * part of its static analysis.  It chooses to use zero as the
+	 * offset value static value.
+	 */
+	unsigned int offset = data_end - data;
+
+	pos = data;
+
+	if (pos + offset > data_end)
+		goto out;
+
+	/* Fails at this line with:
+	 *   "invalid access to packet, off=-1 size=1, R1(id=2,off=0,r=0)"
+	 *   "R1 offset is outside of the packet"
+	 *
+	 * Because verifer used offset==0 it thinks that we are trying
+	 * to access (data - 1), which is not within [data,data_end)
+	 */
+	ptr = pos + (offset - sizeof(*ptr));
+	if (*ptr == 0xFF)
+		return XDP_ABORTED;
+out:
+	return XDP_PASS;
+}

--- a/experiment01-tailgrow/xdp_prog_kern4.c
+++ b/experiment01-tailgrow/xdp_prog_kern4.c
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#include "xdp_data_access_helpers.h"
+
+SEC("xdp_test1")
+int _xdp_test1(struct xdp_md *ctx)
+{
+//	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+	unsigned int len;
+//	len = (data_end - data) - 2 ; // Not working, due to verifier
+	len = 12;
+
+	unsigned int offset = len - 2;
+
+	if (ctx_store_bytes(ctx, offset, data, 2, 0) < 0)
+		return XDP_ABORTED;
+
+	return XDP_PASS;
+}
+


### PR DESCRIPTION
Took Daniel's advice from PR #123 and tried to fix the examples.

Unfortunately this didn't really workout... The tricks satisfied the verifier, but all packets are dropped runtime.

I also tried Ciliums approach, but that also doesn't work when the length is calc dynamically.