### PR TITLE
Fixed a typo in the advanced03-AF_XDP/README

### DIFF
--- a/advanced03-AF_XDP/README.org
+++ b/advanced03-AF_XDP/README.org
@@ -189,4 +189,4 @@ AF_XDP RX:             6 pkts (         1 pps)           0 Kbytes (     0 Mbits/
        TX:             6 pkts (         1 pps)           0 Kbytes (     0 Mbits/s) period:2.000118
 #+end_example
 
-Note that the full solution is present in the ad_xdp_user.c file.
+Note that the full solution is present in the af_xdp_user.c file.


### PR DESCRIPTION
Fix typo: `ad_xdp_user` -> `af_xdp_user`
in advanced03-AF_XDP/README.org