### PR TITLE
Fix in"testenv.sh": Need to disable 'disable_ipv' sysctl to allow ipv6 address assignment.

### DIFF
--- a/basic-solutions/xdp_stats.c
+++ b/basic-solutions/xdp_stats.c
@@ -213,11 +213,13 @@ static int stats_poll(const char *pin_dir, int map_fd, __u32 id,
 			return EXIT_FAIL_BPF;
 		} else if (id != info.id) {
 			printf("BPF map xdp_stats_map changed its ID, restarting\n");
+			close(map_fd);
 			return 0;
 		}
 
 		stats_collect(map_fd, map_type, &record);
 		stats_print(&record, &prev);
+		close(map_fd);
 		sleep(interval);
 	}
 
@@ -275,6 +277,7 @@ int main(int argc, char **argv)
 		err = check_map_fd_info(&info, &map_expect);
 		if (err) {
 			fprintf(stderr, "ERR: map via FD not compatible\n");
+			close(stats_map_fd);
 			return err;
 		}
 		if (verbose) {
@@ -287,6 +290,7 @@ int main(int argc, char **argv)
 		}
 
 		err = stats_poll(pin_dir, stats_map_fd, info.id, info.type, interval);
+		close(stats_map_fd);
 		if (err < 0)
 			return err;
 	}

--- a/testenv/testenv.sh
+++ b/testenv/testenv.sh
@@ -170,6 +170,7 @@ set_sysctls()
     [ -n "$in_ns" ] && nscmd="ip netns exec $in_ns"
     local sysctls=(accept_dad
                    accept_ra
+                   disable_ipv6
                    mldv1_unsolicited_report_interval
                    mldv2_unsolicited_report_interval)
 


### PR DESCRIPTION
I have Ubuntu:20.04 based Docker environment where I am going over tutorial.
I have installed all required tools.
While going over basic02 module, I tried using “testenv.sh setup” which failed  
In assigning ipv6 address to veth end.
It’s because default sysctl "net.ipv6.conf.all.disable_ipv6" has value "1".

This is the failed actual log (ran with bash -x”):

--------------------
  + ip addr add dev veth-basic02 fc00:dead:cafe:1::1/64
  RTNETLINK answers: Permission denied   <<<<<<<<<<<<<<<<<<
--------------------

After disabling "disable_ipv6", testenv setup ran successfully.

 Please merge it in master if change make sense.
