### PR TITLE
Libbpf update

### DIFF
--- a/basic02-prog-by-name/xdp_loader.c
+++ b/basic02-prog-by-name/xdp_loader.c
@@ -151,7 +151,7 @@ static void list_avail_progs(struct bpf_object *obj)
 
 	bpf_object__for_each_program(pos, obj) {
 		if (bpf_program__is_xdp(pos))
-			printf(" %s\n", bpf_program__title(pos, false));
+			printf(" %s\n", bpf_program__section_name(pos));
 	}
 }
 

--- a/common/common.mk
+++ b/common/common.mk
@@ -45,7 +45,7 @@ LDFLAGS ?= -L$(LIBBPF_DIR)
 
 BPF_CFLAGS ?= -I$(LIBBPF_DIR)/build/usr/include/ -I../headers/
 
-LIBS = -l:libbpf.a -lelf $(USER_LIBS)
+LIBS = -l:libbpf.a -lelf -lz $(USER_LIBS)
 
 all: llvm-check $(USER_TARGETS) $(XDP_OBJ) $(COPY_LOADER) $(COPY_STATS)
 

--- a/common/common_user_bpf_xdp.c
+++ b/common/common_user_bpf_xdp.c
@@ -274,7 +274,7 @@ struct bpf_object *load_bpf_and_xdp_attach(struct config *cfg)
 		exit(EXIT_FAIL_BPF);
 	}
 
-	strncpy(cfg->progsec, bpf_program__title(bpf_prog, false), sizeof(cfg->progsec));
+	strncpy(cfg->progsec, bpf_program__section_name(bpf_prog), sizeof(cfg->progsec));
 
 	prog_fd = bpf_program__fd(bpf_prog);
 	if (prog_fd <= 0) {

--- a/setup_dependencies.org
+++ b/setup_dependencies.org
@@ -66,7 +66,7 @@ On a machine running the Fedora Linux distribution, install the packages:
 
 #+begin_example
  $ sudo dnf install clang llvm
- $ sudo dnf install elfutils-libelf-devel libpcap-devel perf
+ $ sudo dnf install elfutils-libelf-devel libpcap-devel zlib-devel perf
 #+end_example
 
 Note also that Fedora by default sets a limit on the amount of locked memory
@@ -86,7 +86,7 @@ Note that you need to do this in the shell you are using to load programs
 On Debian and Ubuntu installations, install the dependencies like this:
 
 #+begin_example
- $ sudo apt install clang llvm libelf-dev libpcap-dev gcc-multilib build-essential
+ $ sudo apt install clang llvm libelf-dev libpcap-dev zlib1g-dev gcc-multilib build-essential
 #+end_example
 
 To install the 'perf' utility, run this on Debian:
@@ -105,7 +105,7 @@ or this on Ubuntu:
 On a machine running the openSUSE distribution, install the packages:
 
 #+begin_example
- $ sudo zypper install clang llvm libelf-devel libpcap-devel perf
+ $ sudo zypper install clang llvm libelf-devel libpcap-devel zlib-devel perf
 #+end_example
 
 * Kernel headers dependency

--- a/tracing02-xdp-monitor/trace_load_and_stats.c
+++ b/tracing02-xdp-monitor/trace_load_and_stats.c
@@ -796,7 +796,7 @@ static struct bpf_object* load_bpf_and_trace_attach(struct config *cfg)
 	}
 
 	bpf_object__for_each_program(prog, obj) {
-		const char *sec = bpf_program__title(prog, true);
+		const char *sec = bpf_program__section_name(prog);
 		char *tp;
 
 		if (!sec) {


### PR DESCRIPTION
This is the minimum conversion needed to update libbpf (as suggested in #155); should we keep it at this, or also port the map definitions to new-style BTF while we're at it?

@netoptimizer WDYT?