### PR TITLE
Update setup_dependencies.org

### DIFF
--- a/setup_dependencies.org
+++ b/setup_dependencies.org
@@ -176,14 +176,7 @@ version.)
 
 ** Packages on Debian
 
-Unfortunately, bpftool is not officially packaged for Debian
-[[https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896165)][yet]].
-
-However, note that an unofficial
-[[https://help.netronome.com/helpdesk/attachments/36025601060][.deb package]]
-is provided by Netronome
-[[https://help.netronome.com/support/solutions/articles/36000050009-agilio-ebpf-2-0-6-extended-berkeley-packet-filter][on their support website]].
-The binary is statically linked, and should work on any x86-64 Linux machine.
+bpftool is officially packaged for Debian. If you are on Buster, you will need to get it from [[https://backports.debian.org/Instructions/][buster-backports]].
 
 ** Packages on openSUSE
 


### PR DESCRIPTION
Debian now has bpftool, in testing and newer, as well as available in buster-backports