### PR TITLE
Fix map pinning error in packet assignments

### DIFF
--- a/packet-solutions/xdp_prog_kern_03.c
+++ b/packet-solutions/xdp_prog_kern_03.c
@@ -159,7 +159,7 @@ int xdp_redirect_func(struct xdp_md *ctx)
 	struct ethhdr *eth;
 	int eth_type;
 	int action = XDP_PASS;
-	unsigned char dst[ETH_ALEN] = { /* TODO: put your values here */ };
+	unsigned char dst[ETH_ALEN+1] = { /* TODO: put your values here. Extra symbol for the null character. */ };
 	unsigned ifindex = 0/* TODO: put your values here */;
 
 	/* These keep track of the next header type and iterator pointer */

--- a/packet03-redirecting/xdp_prog_kern.c
+++ b/packet03-redirecting/xdp_prog_kern.c
@@ -120,8 +120,9 @@ int xdp_redirect_func(struct xdp_md *ctx)
 	struct ethhdr *eth;
 	int eth_type;
 	int action = XDP_PASS;
-	/* unsigned char dst[ETH_ALEN] = {} */	/* Assignment 2: fill in with the MAC address of the left inner interface */
-	/* unsigned ifindex = 0; */		/* Assignment 2: fill in with the ifindex of the left interface */
+	/* unsigned char dst[ETH_ALEN+1] = {} */	/* Assignment 2: fill in with the MAC address of the left inner interface. 
+							   Extra symbol for the null character */
+	/* unsigned ifindex = 0; */			/* Assignment 2: fill in with the ifindex of the left interface */
 
 	/* These keep track of the next header type and iterator pointer */
 	nh.pos = data;


### PR DESCRIPTION
In assignments packet02 and packet03, the following happens:

```
libbpf: failed to pin map: Operation not permitted
ERR: pinning maps
```

I couldn't find the root cause, but as others have pointed out, this change might fix the issue. See [#86].