### PR TITLE
advanced03-AF_XDP: deprecation of bpf_program__title()

### DIFF
--- a/common/common_user_bpf_xdp.c
+++ b/common/common_user_bpf_xdp.c
@@ -274,7 +274,7 @@ struct bpf_object *load_bpf_and_xdp_attach(struct config *cfg)
 		exit(EXIT_FAIL_BPF);
 	}
 
-	strncpy(cfg->progsec, bpf_program__title(bpf_prog, false), sizeof(cfg->progsec));
+	strncpy(cfg->progsec, bpf_program__section_name(bpf_prog), sizeof(cfg->progsec));
 
 	prog_fd = bpf_program__fd(bpf_prog);
 	if (prog_fd <= 0) {


### PR DESCRIPTION
Changing **bpf_program__title()** to **bpf_program__section_name()** due to deprecation of the first in **common/common_user_bpf_xdp.c**.

As stated in **libbpf.h**, line 202:
```
LIBBPF_API LIBBPF_DEPRECATED('BPF program title is confusing term; please use bpf_program__section_name() instead')
```