### PR TITLE
fix missing 'break' in common param processing

### DIFF
--- a/common/common_params.c
+++ b/common/common_params.c
@@ -175,6 +175,7 @@ void parse_cmdline_args(int argc, char **argv,
 		case 'R': /* --dest-mac */
 			dest  = (char *)&cfg->dest_mac;
 			strncpy(dest, optarg, sizeof(cfg->dest_mac));
+			break;
 		case 'c':
 			cfg->xsk_bind_flags &= XDP_ZEROCOPY;
 			cfg->xsk_bind_flags |= XDP_COPY;


### PR DESCRIPTION
I think that setting `dest-mac` don't have to set `XDP_COPY` as well.

Is this a typo?