### PR TITLE
basic01: remove redundant xdp_link_{attach, detach} def and use common defs

### DIFF
--- a/basic01-xdp-pass/Makefile
+++ b/basic01-xdp-pass/Makefile
@@ -12,3 +12,4 @@ COMMON_DIR = ../common/
 
 include $(COMMON_DIR)/common.mk
 COMMON_OBJS := $(COMMON_DIR)/common_params.o
+COMMON_OBJS += $(COMMON_DIR)/common_user_bpf_xdp.o


### PR DESCRIPTION
The basic02-prog-by-name/xdp_loader.c started using the common definitions of xdp_link_{attach, detach} in ../common/common_user_bpf_xdp.h. So also remove the same redundant function defs in basic01-xdp-pass/xdp_pass_user.c and use the common definitions.