### PR TITLE
undefine redefined AF_INET macros

### DIFF
--- a/packet-solutions/xdp_prog_kern_03.c
+++ b/packet-solutions/xdp_prog_kern_03.c
@@ -211,7 +211,9 @@ out:
 	return xdp_stats_record_action(ctx, action);
 }
 
+#undef AF_INET
 #define AF_INET 2
+#undef AF_INET6
 #define AF_INET6 10
 #define IPV6_FLOWINFO_MASK bpf_htonl(0x0FFFFFFF)
 


### PR DESCRIPTION
PR undefines the redefined macros for `AF_INET` and `AF_INET6` macros to avoid a build error in the `packet-solutions` directory.

Fixes #252