### PR TITLE
packet03-redirecting: remove refs to tx_port map from assignment 04 

### DIFF
--- a/packet-solutions/xdp_prog_kern_03.c
+++ b/packet-solutions/xdp_prog_kern_03.c
@@ -304,7 +304,7 @@ int xdp_router_func(struct xdp_md *ctx)
 
 		memcpy(eth->h_dest, fib_params.dmac, ETH_ALEN);
 		memcpy(eth->h_source, fib_params.smac, ETH_ALEN);
-		action = bpf_redirect_map(&tx_port, fib_params.ifindex, 0);
+		action = bpf_redirect(fib_params.ifindex, 0);
 		break;
 	case BPF_FIB_LKUP_RET_BLACKHOLE:    /* dest is blackholed; can be dropped */
 	case BPF_FIB_LKUP_RET_UNREACHABLE:  /* dest is unreachable; can be dropped */

--- a/packet-solutions/xdp_prog_user.c
+++ b/packet-solutions/xdp_prog_user.c
@@ -172,10 +172,6 @@ int main(int argc, char **argv)
 			fprintf(stderr, "can't write iface params\n");
 			return 1;
 		}
-	} else {
-		/* setup 1-1 mapping for the dynamic router */
-		for (i = 1; i < 256; ++i)
-			bpf_map_update_elem(map_fd, &i, &i, 0);
 	}
 
 	return EXIT_OK;

--- a/packet03-redirecting/README.org
+++ b/packet03-redirecting/README.org
@@ -46,13 +46,14 @@ an option to forward packets to egress ports of other interfaces (if the
 corresponding driver supports this feature). This can be done using the
 =bpf_redirect= or =bpf_redirect_map= helpers. These helpers will return the
 =XDP_REDIRECT= value and this is what should the program return. The
-=bpf_redirect= helper actually shouldn't be used in production as it is slow
-and can't be configured from user space.  However, we will use it in the
-Assignment 2 for the sake of simplicity. To use the =bpf_redirect_map= helper
-we need to setup a special map of type =BPF_MAP_TYPE_DEVMAP= which maps virtual
-ports to actual network devices. See [[https://lwn.net/Articles/728146][this
-patch series]] which implemented the XDP redirect functionality. An example of
-usage can be found in the
+=bpf_redirect= helper takes the interface index of the redirect port as
+parameter and may be used with other helpers such as =bpf_fib_lookup=. We will
+use it in Assignment 2 in a simpler way, and again in Assignment 4 with a kernel
+fib lookup. To use the =bpf_redirect_map= helper we need to setup a special map
+of type =BPF_MAP_TYPE_DEVMAP= which maps virtual ports to actual network
+devices. See [[https://lwn.net/Articles/728146][this patch series]] which
+implemented the XDP redirect functionality. An example of usage can be found in
+the
 [[https://github.com/torvalds/linux/blob/master/samples/bpf/xdp_redirect_map_kern.c][xdp_redirect_map_kern.c]]
 file and the corresponding loader.
 
@@ -171,9 +172,9 @@ XDP_REDIRECT         176 pkts (         4 pps)          20 Kbytes (     0 Mbits/
 ** Assignment 3: Extend to a bidirectional router
 
 In the previous assignment we were able to pass packets from one interface to
-the other. However, we were using the wrong =bpf_redirect= helper and needed to
-hardcode interface number and MAC addresses. This is not useful and we will use
-better techniques in this Assignment.
+the other. However, we needed to hard code the interface number and MAC
+addresses. This is not useful and we will use better techniques in this
+Assignment.
 
 This Assignment will show how to use the =bpf_redirect_map= function. Besides
 that, to make the program more useful we will use a map which will contain a
@@ -246,13 +247,11 @@ and return =XDP_PASS= when packets destined to outer interfaces, but this
 doesn't cover all cases and wouldn't it be better to dynamically lookup
 where each packet should go?
 
-This assignment teaches to use the =bpf_fib_lookup= helper. This function lets
-XDP and TC programs to access the kernel routing table and will return an
-ifindex of interface to forward packet to.  As was noted the =bpf_redirect_map=
-function accepts virtual ports, so to use ifindexes you will need to update the
-=xdp_prog_user.c= program to setup 1-1 mapping between virtual ports and
-network devices where each virtual port corresponds to a device with the same
-ifindex.
+This assignment teaches how to use the =bpf_fib_lookup= helper. This function
+lets XDP and TC programs access the kernel routing table and will return the
+ifindex of interface to forward packet to, along with source and destination
+mac addresses. After updating the Ethernet header, we can then redirect the
+packet to this interface with the =bpf_redirect= function.
 
 The Assignment, for the most part, reproduces the
 [[https://github.com/torvalds/linux/blob/master/samples/bpf/xdp_fwd_kern.c][xdp_fwd_kern.c]]
@@ -285,10 +284,6 @@ $ t load -n tres -- -F --progsec xdp_router
 $ t exec -n uno -- ./xdp_loader -d veth0 -F --progsec xdp_pass
 $ t exec -n dos -- ./xdp_loader -d veth0 -F --progsec xdp_pass
 $ t exec -n tres -- ./xdp_loader -d veth0 -F --progsec xdp_pass
-
-$ sudo ./xdp_prog_user -d uno
-$ sudo ./xdp_prog_user -d dos
-$ sudo ./xdp_prog_user -d tres
 
 $ sudo ./xdp_stats -d uno
 $ sudo ./xdp_stats -d dos

--- a/packet03-redirecting/README.org
+++ b/packet03-redirecting/README.org
@@ -131,11 +131,11 @@ Env 1                         Env 2
 #+end_src
 Setup the two environments, patch the =xdp_redirect= program accordingly, and
 attach it to the =right= interface.  Don't forget to attach a dummy program to
-the left inner interface like this:
+the left /inner/ interface like this:
 #+begin_src sh
 $ t exec -n left -- ./xdp_loader -d veth0 -F --progsec xdp_pass
 #+end_src
-To test load the program, enter the right environment, and ping the inner
+To test load the program, enter the right environment, and ping the /inner/
 interface of the left environment (your IPv6 address may be different):
 #+begin_src sh
 $ t enter -n right

--- a/packet03-redirecting/xdp_prog_kern.c
+++ b/packet03-redirecting/xdp_prog_kern.c
@@ -242,10 +242,10 @@ int xdp_router_func(struct xdp_md *ctx)
 			ip6h->hop_limit--;
 
 		/* Assignment 4: fill in the eth destination and source
-		 * addresses and call the bpf_redirect_map function */
+		 * addresses and call the bpf_redirect function */
 		/* memcpy(eth->h_dest, ???, ETH_ALEN); */
 		/* memcpy(eth->h_source, ???, ETH_ALEN); */
-		/* action = bpf_redirect_map(&tx_port, ???, 0); */
+		/* action = bpf_redirect(???, 0); */
 		break;
 	case BPF_FIB_LKUP_RET_BLACKHOLE:    /* dest is blackholed; can be dropped */
 	case BPF_FIB_LKUP_RET_UNREACHABLE:  /* dest is unreachable; can be dropped */

--- a/packet03-redirecting/xdp_prog_user.c
+++ b/packet03-redirecting/xdp_prog_user.c
@@ -143,8 +143,6 @@ int main(int argc, char **argv)
 			fprintf(stderr, "can't write iface params\n");
 			return 1;
 		}
-	} else {
-		/* Assignment 4: setup 1-1 mapping for the dynamic router */
 	}
 
 	return EXIT_OK;

--- a/setup_dependencies.org
+++ b/setup_dependencies.org
@@ -155,12 +155,16 @@ your system. It also offers simple manipulation of eBPF programs and maps.
 The =bpftool= is part of the Linux kernel tree under [[https://github.com/torvalds/linux/tree/master/tools/bpf/bpftool][tools/bpf/bpftool/]], but
 some Linux distributions also ship the tool as a software package.
 
+If you are planning on working through the packet processing examples you
+should also install tcpdump.
+
 ** Packages on Fedora
 
 On a machine running the Fedora Linux distribution, install package:
 
 #+begin_example
  $ sudo dnf install bpftool
+ $ sudo dnf install tcpdump
 #+end_example
 
 ** Packages on Ubuntu
@@ -169,6 +173,7 @@ Starting from Ubuntu 19.10, bpftool can be installed with:
 
 #+begin_example
  $ sudo apt install linux-tools-common linux-tools-generic
+ $ sudo apt install tcpdump
 #+end_example
 
 (Ubuntu 18.04 LTS also has it, but it is an old and quite limited bpftool
@@ -180,6 +185,7 @@ Starting from Debian Bullseye, bpftool can be installed with:
 
 #+begin_example
  $ sudo apt install bpftool
+ $ sudo apt install tcpdump
 #+end_example
 
 (If you are on Debian Buster, you can get it from [[https://backports.debian.org][buster-backports]].)
@@ -190,4 +196,5 @@ On a machine running the openSUSE Tumbleweed distribution, install package:
 
 #+begin_example
  $ sudo zypper install bpftool
+ $ sudo zypper install tcpdump
 #+end_example


### PR DESCRIPTION
Looking up the tx_port map for a 1:1 mapping in packet 03 assignment 04 is pointless. If bpf_fib_lookup returns a successful lookup, it is much simplier and more obvious to directly call bpf_redirect with the information from the fib without the map lookup. 

Other minor documentation fixes also included. 
