### PR TITLE
Fix tracing02-xdp-monitor example

### DIFF
--- a/tracing02-xdp-monitor/README.org
+++ b/tracing02-xdp-monitor/README.org
@@ -1,60 +1,62 @@
 # -*- fill-column: 76; -*-
-#+TITLE: Tutorial: Tracing02 - monitor xdp raw tracepoints
+#+TITLE: Tutorial: Tracing02 - monitor xdp tracepoints
 #+OPTIONS: ^:nil
 
 In this lesson we will show how to attach to and monitor all
-xdp related raw tracepoints and some related info to user space
+xdp related tracepoints and some related info to user space
 stat application.
 
 * Table of Contents                                                     :TOC:
-- [[#raw-tracepoints][RAW tracepoints]]
+- [[#tracepoints][Tracepoints]]
 - [[#assignments][Assignments]]
   - [[#assignment-1-monitor-all-xdp-tracepoints][Assignment 1: Monitor all xdp tracepoints]]
 
-* RAW tracepoints
+* Tracepoints
 
-The RAW tracepoint is eBPF alternative to standard tracepoint,
-which allows attaching eBPF program to tracepoint without the
-perf layer being involved/executed.
+Tracepoints are useful for debugging XDP, expecially for XDP_REDIRECT.
 
-The bpf library expects the raw tracepoint eBPF program to be stored
+To gain performance XDP_REDIRECT does RX-bulking towards destinations, which
+unfortunately means that XDP-prog doesn't get errors directly returned
+through the BPF-helper call =bpf_redirect()= (or =bpf_redirect_map=).
+Instead these errors can be debugged via using the XDP tracepoint available
+in the kernel.
+
+The bpf library expects the tracepoint eBPF program to be stored
 in a section with following name:
 
 #+begin_example sh
-raw_tracepoint/<sys>/<tracepoint>
+tracepoint/<sys>/<tracepoint>
 #+end_example
 
 where =<sys>= is the tracepoint subsystem and =<tracepoint>= is
 the tracepoint name, which can be done with following construct:
 
 #+begin_example sh
-SEC("raw_tracepoint/xdp/xdp_exception")
+SEC("tracepoint/xdp/xdp_exception")
 int trace_xdp_exception(struct xdp_exception_ctx *ctx)
 #+end_example
 
-The libbpf library exports interface to load and attach raw tracepoint
-programs, following call will load every program in the =cfg->filename=
-object as raw tracepoint programs:
+Via the libbpf library =open= and =load= the bpf_object the usual way. E.g.
 
-#+begin_example sh
-err = bpf_prog_load(cfg->filename, BPF_PROG_TYPE_RAW_TRACEPOINT, &obj, &bpf_fd));
-#+end_example
+#+begin_src C
+	obj = bpf_object__open_file(cfg->filename, NULL)
+	bpf_object__load(obj);
+#+end_src
 
 You can then iterate through all the programs and attach
-every program to the raw tracepoint:
+every program to the tracepoint:
 
-#+begin_example sh
+#+begin_src C
 bpf_object__for_each_program(prog, obj) {
 	...
-	bpf_fd = bpf_program__fd(prog);
-	...
-	err = bpf_raw_tracepoint_open(tp, bpf_fd);
+	tp_link = bpf_program__attach_tracepoint(prog, "xdp", tp);
+	err = libbpf_get_error(tp_link);
 	...
 }
-#+end_example
+#+end_src
 
 for more details please check load_bpf_and_trace_attach function
-in trace_load_and_stats.c object.
+in [[file:trace_load_and_stats.c]] object.
 
 * Assignments
 

--- a/tracing02-xdp-monitor/README.org
+++ b/tracing02-xdp-monitor/README.org
@@ -10,6 +10,9 @@ stat application.
 - [[#tracepoints][Tracepoints]]
 - [[#assignments][Assignments]]
   - [[#assignment-1-monitor-all-xdp-tracepoints][Assignment 1: Monitor all xdp tracepoints]]
+- [[#alternative-solutions][Alternative solutions]]
+  - [[#bpftrace][bpftrace]]
+  - [[#perf-record][perf record]]
 
 * Tracepoints
 
@@ -77,3 +80,43 @@ Exception       total   0            91           XDP_UNKNOWN
 cpumap-kthread  total   0            0            0          
 devmap-xmit     total   0            0            0.00        
 #+end_example
+
+* Alternative solutions
+
+** bpftrace
+
+The bpftrace tool is easy to construct an oneliner that can capture and
+e.g. count the events of a given tracepoint. E.g. attaching to all XDP
+tracepoints and counting them:
+
+#+begin_example sh
+sudo bpftrace -e 'tracepoint:xdp:* { @cnt[probe] = count(); }'
+Attaching 12 probes...
+^C
+
+@cnt[tracepoint:xdp:mem_connect]: 18
+@cnt[tracepoint:xdp:mem_disconnect]: 18
+@cnt[tracepoint:xdp:xdp_exception]: 19605
+@cnt[tracepoint:xdp:xdp_devmap_xmit]: 1393604
+@cnt[tracepoint:xdp:xdp_redirect]: 22292200
+#+end_example
+
+To extract the "ERRNO" being return as part of the =err= parameter, this
+bpftrace oneliner can be useful:
+
+#+begin_example sh
+ sudo bpftrace -e \
+  'tracepoint:xdp:xdp_redirect*_err {@redir_errno[-args->err] = count();}
+   tracepoint:xdp:xdp_devmap_xmit {@devmap_errno[-args->err] = count();}'
+#+end_example
+
+** perf record
+
+The perf tool also supports recording tracepoints of the the box:
+
+#+begin_src sh
+  perf record -a -e xdp:xdp_redirect_err \
+       -e xdp:xdp_redirect_map_err \
+       -e xdp:xdp_exception \
+       -e xdp:xdp_devmap_xmit
+#+end_src

--- a/tracing02-xdp-monitor/trace_load_and_stats.c
+++ b/tracing02-xdp-monitor/trace_load_and_stats.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-static const char *__doc__ = "XDP loader and stats program\n"
-	" - Allows selecting BPF section --progsec name to XDP-attach to --dev\n";
+static const char *__doc__ = "XDP monitor via tracepoints\n";
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tracing02-xdp-monitor/trace_load_and_stats.c
+++ b/tracing02-xdp-monitor/trace_load_and_stats.c
@@ -787,11 +787,20 @@ static struct bpf_object* load_bpf_and_trace_attach(struct config *cfg)
 {
 	struct bpf_object *obj;
 	struct bpf_program *prog;
-	int bpf_fd, err;
+	struct bpf_link *tp_link;
+	int err;
 
-	if (bpf_prog_load(cfg->filename, BPF_PROG_TYPE_RAW_TRACEPOINT, &obj, &bpf_fd)) {
-		fprintf(stderr, "ERR: failed to load program\n");
+	obj = bpf_object__open_file(cfg->filename, NULL);
+	if (libbpf_get_error(obj)) {
+		fprintf(stderr, "ERR: opening BPF object file %s failed\n",
+			cfg->filename);
 		return NULL;
+	}
+
+	if (bpf_object__load(obj)) {
+		fprintf(stderr, "ERR: loading BPF object file %s failed\n",
+			cfg->filename);
+		goto err;
 	}
 
 	bpf_object__for_each_program(prog, obj) {
@@ -810,9 +819,13 @@ static struct bpf_object* load_bpf_and_trace_attach(struct config *cfg)
 		}
 
 		tp++;
-		bpf_fd = bpf_program__fd(prog);
 
-		err = bpf_raw_tracepoint_open(tp, bpf_fd);
+		if (verbose)
+			printf("Attach tracepoint %s \t(prog sec:%s)\n", tp, sec);
+
+		tp_link = bpf_program__attach_tracepoint(prog, "xdp", tp);
+
+		err = libbpf_get_error(tp_link);
 		if (err < 0) {
 			fprintf(stderr, "ERR: failed to open raw tracepoint for %s, (%d %s)\n",
 				tp, -errno, strerror(errno));

--- a/tracing02-xdp-monitor/trace_prog_kern.c
+++ b/tracing02-xdp-monitor/trace_prog_kern.c
@@ -220,13 +220,11 @@ BPF_ANNOTATE_KV_PAIR(devmap_xmit_cnt, int, struct datarec);
  * Code in:         kernel/include/trace/events/xdp.h
  */
 struct devmap_xmit_ctx {
-	int map_id;		//	offset: 0; size:4; signed:1;
+	int from_ifindex;	//	offset: 0; size:4; signed:1;
 	__u32 act;		//	offset: 4; size:4; signed:0;
-	__u32 map_index;	//	offset: 8; size:4; signed:0;
+	int to_ifindex;		//	offset: 8; size:4; signed:1;
 	int drops;		//	offset:12; size:4; signed:1;
 	int sent;		//	offset:16; size:4; signed:1;
-	int from_ifindex;	//	offset:20; size:4; signed:1;
-	int to_ifindex;	//	offset:24; size:4; signed:1;
 	int err;		//	offset:28; size:4; signed:1;
 };
 

--- a/tracing02-xdp-monitor/trace_prog_kern.c
+++ b/tracing02-xdp-monitor/trace_prog_kern.c
@@ -1,8 +1,10 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
 
 #include "bpf_legacy.h"
+//#include "bpf_tracing_macros.h"
 
 struct bpf_map_def SEC("maps") redirect_err_cnt = {
 	.type		= BPF_MAP_TYPE_PERCPU_ARRAY,
@@ -21,10 +23,10 @@ struct bpf_map_def SEC("maps") exception_cnt = {
 };
 
 /* Tracepoint format: /sys/kernel/debug/tracing/events/xdp/xdp_redirect/format
- * Notice: For raw_tracepoints first 8 bytes are not part of 'format' struct
  * Code in:                kernel/include/trace/events/xdp.h
  */
 struct xdp_redirect_ctx {
+	__u64 pad;
 	int prog_id;		//	offset: 0; size:4; signed:1;
 	__u32 act;		//	offset: 4  size:4; signed:0;
 	int ifindex;		//	offset: 8  size:4; signed:1;
@@ -63,43 +65,43 @@ int xdp_redirect_collect_stat(struct xdp_redirect_ctx *ctx)
 	 */
 }
 
-SEC("raw_tracepoint/xdp/xdp_redirect_err")
+SEC("tracepoint/xdp/xdp_redirect_err")
 int trace_xdp_redirect_err(struct xdp_redirect_ctx *ctx)
 {
 	return xdp_redirect_collect_stat(ctx);
 }
 
-SEC("raw_tracepoint/xdp/xdp_redirect_map_err")
+SEC("tracepoint/xdp/xdp_redirect_map_err")
 int trace_xdp_redirect_map_err(struct xdp_redirect_ctx *ctx)
 {
 	return xdp_redirect_collect_stat(ctx);
 }
 
 /* Likely unloaded when prog starts */
-SEC("raw_tracepoint/xdp/xdp_redirect")
+SEC("tracepoint/xdp/xdp_redirect")
 int trace_xdp_redirect(struct xdp_redirect_ctx *ctx)
 {
 	return xdp_redirect_collect_stat(ctx);
 }
 
 /* Likely unloaded when prog starts */
-SEC("raw_tracepoint/xdp/xdp_redirect_map")
+SEC("tracepoint/xdp/xdp_redirect_map")
 int trace_xdp_redirect_map(struct xdp_redirect_ctx *ctx)
 {
 	return xdp_redirect_collect_stat(ctx);
 }
 
 /* Tracepoint format: /sys/kernel/debug/tracing/events/xdp/xdp_exception/format
- * Notice: For raw_tracepoints first 8 bytes are not part of 'format' struct
  * Code in:                kernel/include/trace/events/xdp.h
  */
 struct xdp_exception_ctx {
+	__u64 pad;
 	int prog_id;	//	offset:0; size:4; signed:1;
 	__u32 act;	//	offset:4; size:4; signed:0;
 	int ifindex;	//	offset:8; size:4; signed:1;
 };
 
-SEC("raw_tracepoint/xdp/xdp_exception")
+SEC("tracepoint/xdp/xdp_exception")
 int trace_xdp_exception(struct xdp_exception_ctx *ctx)
 {
 	__u64 *cnt;
@@ -141,10 +143,10 @@ struct bpf_map_def SEC("maps") cpumap_kthread_cnt = {
 };
 
 /* Tracepoint: /sys/kernel/debug/tracing/events/xdp/xdp_cpumap_enqueue/format
- * Notice: For raw_tracepoints first 8 bytes are not part of 'format' struct
  * Code in:         kernel/include/trace/events/xdp.h
  */
 struct cpumap_enqueue_ctx {
+	__u64 pad;
 	int map_id;		//	offset: 0; size:4; signed:1;
 	__u32 act;		//	offset: 4; size:4; signed:0;
 	int cpu;		//	offset: 8; size:4; signed:1;
@@ -153,7 +155,7 @@ struct cpumap_enqueue_ctx {
 	int to_cpu;		//	offset:20; size:4; signed:1;
 };
 
-SEC("raw_tracepoint/xdp/xdp_cpumap_enqueue")
+SEC("tracepoint/xdp/xdp_cpumap_enqueue")
 int trace_xdp_cpumap_enqueue(struct cpumap_enqueue_ctx *ctx)
 {
 	__u32 to_cpu = ctx->to_cpu;
@@ -176,10 +178,10 @@ int trace_xdp_cpumap_enqueue(struct cpumap_enqueue_ctx *ctx)
 }
 
 /* Tracepoint: /sys/kernel/debug/tracing/events/xdp/xdp_cpumap_kthread/format
- * Notice: For raw_tracepoints first 8 bytes are not part of 'format' struct
  * Code in:         kernel/include/trace/events/xdp.h
  */
 struct cpumap_kthread_ctx {
+	__u64 pad;
 	int map_id;		//	offset: 0; size:4; signed:1;
 	__u32 act;		//	offset: 4; size:4; signed:0;
 	int cpu;		//	offset: 8; size:4; signed:1;
@@ -188,7 +190,7 @@ struct cpumap_kthread_ctx {
 	int sched;		//	offset:20; size:4; signed:1;
 };
 
-SEC("raw_tracepoint/xdp/xdp_cpumap_kthread")
+SEC("tracepoint/xdp/xdp_cpumap_kthread")
 int trace_xdp_cpumap_kthread(struct cpumap_kthread_ctx *ctx)
 {
 	struct datarec *rec;
@@ -216,10 +218,10 @@ struct bpf_map_def SEC("maps") devmap_xmit_cnt = {
 BPF_ANNOTATE_KV_PAIR(devmap_xmit_cnt, int, struct datarec);
 
 /* Tracepoint: /sys/kernel/debug/tracing/events/xdp/xdp_devmap_xmit/format
- * Notice: For raw_tracepoints first 8 bytes are not part of 'format' struct
  * Code in:         kernel/include/trace/events/xdp.h
  */
 struct devmap_xmit_ctx {
+	__u64 pad;
 	int from_ifindex;	//	offset: 0; size:4; signed:1;
 	__u32 act;		//	offset: 4; size:4; signed:0;
 	int to_ifindex;		//	offset: 8; size:4; signed:1;
@@ -228,7 +230,7 @@ struct devmap_xmit_ctx {
 	int err;		//	offset:28; size:4; signed:1;
 };
 
-SEC("raw_tracepoint/xdp/xdp_devmap_xmit")
+SEC("tracepoint/xdp/xdp_devmap_xmit")
 int trace_xdp_devmap_xmit(struct devmap_xmit_ctx *ctx)
 {
 	struct datarec *rec;


### PR DESCRIPTION
The use of `raw_tracepoint` in the `tracing02-xdp-monitor` have been broken from day one.

It was @olsajiri that converted my original `xdp_monitor` (from kernel/samples/bpf) into a trace usage example.
In that process we decided to use `raw_tracepoints`, but we didn't do the conversion from normal tracepoint to raw_tracepoint correctly.

In the PR I'm converting back to the original tracepoint usage.

As can be seen upstream in kernel/samples/bpf/ the real approach would be to use the newer `SEC("tp_bpf/")`, but the libbpf in xdp-tutorial is out-of-date, so I couldn't do that conversion.

The priority in this PR is to avoid showing invalid BPF code as an example.