### PR TITLE
fix reference to libbpf_num_possible_cpus

### DIFF
--- a/basic03-map-counter/README.org
+++ b/basic03-map-counter/README.org
@@ -208,7 +208,7 @@ the switch-case statement in function =map_collect()=:
 void map_get_value_percpu_array(int fd, __u32 key, struct datarec *value)
 {
 	/* For percpu maps, user space gets a value per possible CPU */
-	unsigned int nr_cpus = bpf_num_possible_cpus();
+	unsigned int nr_cpus = libbpf_num_possible_cpus();
 	struct datarec values[nr_cpus];
 	__u64 sum_bytes = 0;
 	__u64 sum_pkts = 0;

--- a/basic03-map-counter/xdp_load_and_stats.c
+++ b/basic03-map-counter/xdp_load_and_stats.c
@@ -153,7 +153,7 @@ void map_get_value_array(int fd, __u32 key, struct datarec *value)
 void map_get_value_percpu_array(int fd, __u32 key, struct datarec *value)
 {
 	/* For percpu maps, userspace gets a value per possible CPU */
-	// unsigned int nr_cpus = bpf_num_possible_cpus();
+	// unsigned int nr_cpus = libbpf_num_possible_cpus();
 	// struct datarec values[nr_cpus];
 
 	fprintf(stderr, "ERR: %s() not impl. see assignment#3", __func__);


### PR DESCRIPTION
Hi!

Thanks for making this great tutorial available.

I noticed a problem in tutorial `basic03` which already has a linked issue: #365, so here is a fix proposal.
I have tested this on my setup with:
- Ubuntu 22.04.3 LTS
- Linux 5.15.0-94-generic
- Aarch64

Fix #365