### PR TITLE
Update packet03-redirecting/README.org to meet kernel source tree update

### DIFF
--- a/packet03-redirecting/README.org
+++ b/packet03-redirecting/README.org
@@ -54,7 +54,7 @@ of type =BPF_MAP_TYPE_DEVMAP= which maps virtual ports to actual network
 devices. See [[https://lwn.net/Articles/728146][this patch series]] which
 implemented the XDP redirect functionality. An example of usage can be found in
 the
-[[https://github.com/torvalds/linux/blob/master/samples/bpf/xdp_redirect_map_kern.c][xdp_redirect_map_kern.c]]
+[[https://github.com/torvalds/linux/blob/v5.14/samples/bpf/xdp_redirect_map_kern.c][xdp_redirect_map_kern.c]]
 file and the corresponding loader.
 
 ** Building a router using a kernel helper

--- a/packet03-redirecting/README.org
+++ b/packet03-redirecting/README.org
@@ -54,7 +54,7 @@ of type =BPF_MAP_TYPE_DEVMAP= which maps virtual ports to actual network
 devices. See [[https://lwn.net/Articles/728146][this patch series]] which
 implemented the XDP redirect functionality. An example of usage can be found in
 the
-[[https://github.com/torvalds/linux/blob/v5.14/samples/bpf/xdp_redirect_map_kern.c][xdp_redirect_map_kern.c]]
+[[https://github.com/xdp-project/xdp-tools/blob/master/xdp-bench/xdp_redirect_devmap.bpf.c][xdp_redirect_map_kern.c]]
 file and the corresponding loader.
 
 ** Building a router using a kernel helper


### PR DESCRIPTION
[xdp_redirect_map_kern.c](https://github.com/torvalds/linux/blob/v5.14/samples/bpf/xdp_redirect_map_kern.c) is no more present in the current Linux Kernel source tree in GitHub. Starting from [this commit](https://github.com/torvalds/linux/commit/54af769db92a47be8a9d23a4434dbd343b3), the file's name has changed and most of its content has moved to some other files. Therefore, to retain the integrity of the lessons of **xdp-tutorial/packet03-redirecting**, we can point to this file in last stable release tag of Linux Kernel source tree where the file was present. The job was done in this PR. 