### PR TITLE
fix the dependencies of old loader

### DIFF
--- a/basic02-prog-by-name/README.org
+++ b/basic02-prog-by-name/README.org
@@ -119,15 +119,6 @@ sudo ./xdp_loader --dev veth-basic02 --progname xdp_drop_func
 sudo ./xdp_loader --dev veth-basic02 --progname xdp_pass_func
 #+end_example
 
-The testenv script also has a helper command for "load" which will use the
-=xdp_loader= program in the current directory:
-#+begin_example
-sudo ../testenv/testenv.sh load --name veth-basic02
-sudo ../testenv/testenv.sh load --name veth-basic02 -- --unload-all
-sudo ../testenv/testenv.sh load --name veth-basic02 -- --progname xdp_drop_func
-sudo ../testenv/testenv.sh load --name veth-basic02 -- --progname xdp_pass_func
-#+end_example
-
 *** A note about: The test environment and veth packets directions
 When you load an XDP program on the interface visible on your host machine,
 it will operate on all packets arriving *to* that interface. And since

--- a/common/xdp_stats_kern.h
+++ b/common/xdp_stats_kern.h
@@ -18,6 +18,7 @@ struct {
 	__type(key, __u32);
 	__type(value, struct datarec);
 	__uint(max_entries, XDP_ACTION_MAX);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } xdp_stats_map SEC(".maps");
 
 static __always_inline

--- a/packet01-parsing/README.org
+++ b/packet01-parsing/README.org
@@ -26,9 +26,9 @@ programs.
 
 * Setup notes
 
-We will use the loader from the basic04 lesson. The Makefile in this directory
+We will use the loader from xdp-tools. The Makefile in this directory
 contains a rule to copy it over to this directory, so you can run it as
-=./xdp_loader= after running =make=. The =testenv.sh= script will use this
+=./xdp-loader= after running =make=. The =testenv.sh= script will use this
 when run with the =load= command. In the example below, we assume you've
 installed the alias for testenv (by running =eval $(./testenv.sh alias)=),
 so all examples will use the short =t= command to refer to the =testenv.sh=

--- a/packet03-redirecting/README.org
+++ b/packet03-redirecting/README.org
@@ -93,8 +93,8 @@ supported and load the XDP program. Note that we also need to load a dummy
 section.
 #+begin_src sh
 $ t setup -n test --legacy-ip
-$ t exec -n test -- ./xdp_loader -d veth0 -F --progsec xdp_pass
-$ t load -n test -- -F --progsec xdp_icmp_echo
+$ t exec -n test -- ./xdp-loader load --prog-name xdp_pass_func veth0 xdp_prog_kern.o
+$ t load -n test -- --prog-name xdp_icmp_echo_func xdp_prog_kern.o
 #+end_src
 Ping the host and use the =xdp_stat= program to check that the ICMP echo server
 actually returned =XDP_TX=. Repeat for both address families (you can pass

--- a/packet03-redirecting/README.org
+++ b/packet03-redirecting/README.org
@@ -134,7 +134,7 @@ Setup the two environments, patch the =xdp_redirect= program accordingly, and
 attach it to the =right= interface.  Don't forget to attach a dummy program to
 the left /inner/ interface like this:
 #+begin_src sh
-$ t exec -n left -- ./xdp_loader -d veth0 -F --progsec xdp_pass
+$ t exec -n left -- ./xdp-loader load --prog-name xdp_pass_func veth0 xdp_prog_kern.o
 #+end_src
 To test load the program, enter the right environment, and ping the /inner/
 interface of the left environment (your IPv6 address may be different):
@@ -186,13 +186,13 @@ the =xdp_prog_user.c= program.
 To test the code, configure environment as in the Assignment 2 and install the
 =xdp_redirect_map= program on both interfaces:
 #+begin_src sh
-$ t load -n left -- -F --progsec xdp_redirect_map
-$ t load -n right -- -F --progsec xdp_redirect_map
+$ t load -n left -- --prog-name xdp_redirect_map_func xdp_prog_kern.o
+$ t load -n right -- --prog-name xdp_redirect_map_func xdp_prog_kern.o
 #+end_src
 Don't forget about dummy programs for inner interfaces:
 #+begin_src sh
-$ t exec -n left -- ./xdp_loader -d veth0 -F --progsec xdp_pass
-$ t exec -n right -- ./xdp_loader -d veth0 -F --progsec xdp_pass
+$ t exec -n left -- ./xdp-loader load --prog-name xdp_pass_func veth0 xdp_prog_kern.o
+$ t exec -n right -- ./xdp-loader load --prog-name xdp_pass_func veth0 xdp_prog_kern.o
 #+end_src
 Configure parameters for both interfaces using the new =xdp_prog_user= helper.
 For simplicity there is a new special helper, =t redirect=, which will
@@ -277,13 +277,13 @@ $ t setup -n tres --legacy-ip
 $ sudo sysctl net.ipv4.conf.all.forwarding=1
 $ sudo sysctl net.ipv6.conf.all.forwarding=1
 
-$ t load -n uno -- -F --progsec xdp_router
-$ t load -n dos -- -F --progsec xdp_router
-$ t load -n tres -- -F --progsec xdp_router
+$ t load -n uno -- --prog-name xdp_router_func xdp_prog_kern.o
+$ t load -n dos -- --prog-name xdp_router_func xdp_prog_kern.o
+$ t load -n tres -- --prog-name xdp_router_func xdp_prog_kern.o
 
-$ t exec -n uno -- ./xdp_loader -d veth0 -F --progsec xdp_pass
-$ t exec -n dos -- ./xdp_loader -d veth0 -F --progsec xdp_pass
-$ t exec -n tres -- ./xdp_loader -d veth0 -F --progsec xdp_pass
+$ t exec -n uno -- ./xdp-loader load --prog-name xdp_pass_func veth0 xdp_prog_kern.o
+$ t exec -n dos -- ./xdp-loader load --prog-name xdp_pass_func veth0 xdp_prog_kern.o
+$ t exec -n tres -- ./xdp-loader load --prog-name xdp_pass_func veth0 xdp_prog_kern.o
 
 $ sudo ./xdp_stats -d uno
 $ sudo ./xdp_stats -d dos

--- a/packet03-redirecting/xdp_prog_kern.c
+++ b/packet03-redirecting/xdp_prog_kern.c
@@ -20,6 +20,7 @@ struct {
 	__type(key, int);
 	__type(value, int);
 	__uint(max_entries, 256);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } tx_port SEC(".maps");
 
 
@@ -28,6 +29,7 @@ struct {
 	__type(key,  unsigned char[ETH_ALEN]);
 	__type(value, unsigned char[ETH_ALEN]);
 	__uint(max_entries, 1);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } redirect_params SEC(".maps");
 
 static __always_inline void swap_src_dst_mac(struct ethhdr *eth)

--- a/testenv/testenv.sh
+++ b/testenv/testenv.sh
@@ -23,7 +23,7 @@ CLEANUP_FUNC=
 STATEFILE=
 CMD=
 NS=
-XDP_LOADER=./xdp_loader
+XDP_LOADER=./xdp-loader
 XDP_STATS=./xdp_stats
 LEGACY_IP=0
 USE_VLAN=0
@@ -450,7 +450,9 @@ xdp_load()
     get_nsname && ensure_nsname
 
     [ -x "$XDP_LOADER" ] || die "Loader '$XDP_LOADER' is not executable"
-    $XDP_LOADER --dev "$NS" "$@"
+    local objfile=${!#}
+    local load_opts="${@:1:$#-1} --pin-path /sys/fs/bpf/$NS"
+    $XDP_LOADER load $load_opts $NS $objfile
 }
 
 xdp_unload()
@@ -458,7 +460,7 @@ xdp_unload()
     get_nsname && ensure_nsname
 
     [ -x "$XDP_LOADER" ] || die "Loader '$XDP_LOADER' is not executable"
-    $XDP_LOADER --dev "$NS" --unload "$@"
+    $XDP_LOADER unload "$@" "$NS"
 }
 
 xdp_stats()


### PR DESCRIPTION
Commit 0ded568, made by @donaldh and already merged, changed COPY_LOADER from `xdp_loader` to `xdp-loader`, but there are still dependencies on `xdp_loader`.

I fixed the following:
- Used `xdp-loader` instead of `xdp_loader` in testenv.sh.
- Added a pinning attribute for the maps to be used in packet03. These maps are expected to be loaded by `xdp-loader` and must be pinned.
- Updated README.

## related issues

#393
