### PR TITLE
fix the assignment style

### DIFF
--- a/advanced03-AF_XDP/Makefile
+++ b/advanced03-AF_XDP/Makefile
@@ -2,9 +2,9 @@
 
 XDP_TARGETS  := af_xdp_kern
 USER_TARGETS := af_xdp_user
-LDLIBS+= -lpthread
+LDLIBS += -lpthread
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
 include $(COMMON_DIR)/common.mk
 COMMON_OBJS := $(COMMON_DIR)/common_params.o

--- a/basic-solutions/Makefile
+++ b/basic-solutions/Makefile
@@ -2,9 +2,8 @@
 
 USER_TARGETS := xdp_stats xdp_loader
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
-# Extend with another COMMON_OBJS
-COMMON_OBJS += $(COMMON_DIR)/common_user_bpf_xdp.o
+COMMON_OBJS := $(COMMON_DIR)/common_user_bpf_xdp.o
 
 include $(COMMON_DIR)/common.mk

--- a/basic01-xdp-pass/Makefile
+++ b/basic01-xdp-pass/Makefile
@@ -7,7 +7,7 @@ LLC ?= llc
 CLANG ?= clang
 CC := gcc
 
-COMMON_DIR = ../common
-COMMON_OBJS += $(COMMON_DIR)/common_user_bpf_xdp.o
+COMMON_DIR := ../common
+COMMON_OBJS := $(COMMON_DIR)/common_user_bpf_xdp.o
 
 include $(COMMON_DIR)/common.mk

--- a/basic02-prog-by-name/Makefile
+++ b/basic02-prog-by-name/Makefile
@@ -3,8 +3,8 @@
 XDP_TARGETS  := xdp_prog_kern
 USER_TARGETS := xdp_loader
 
-COMMON_DIR = ../common
-COMMON_OBJS += $(COMMON_DIR)/common_user_bpf_xdp.o
+COMMON_DIR := ../common
+COMMON_OBJS := $(COMMON_DIR)/common_user_bpf_xdp.o
 
 include $(COMMON_DIR)/common.mk
 

--- a/basic03-map-counter/Makefile
+++ b/basic03-map-counter/Makefile
@@ -4,7 +4,7 @@
 XDP_TARGETS  := xdp_prog_kern
 USER_TARGETS := xdp_load_and_stats
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
-COMMON_OBJS += $(COMMON_DIR)/common_user_bpf_xdp.o
+COMMON_OBJS := $(COMMON_DIR)/common_user_bpf_xdp.o
 include $(COMMON_DIR)/common.mk

--- a/basic04-pinning-maps/Makefile
+++ b/basic04-pinning-maps/Makefile
@@ -4,9 +4,8 @@ XDP_TARGETS  := xdp_prog_kern
 USER_TARGETS := xdp_loader
 USER_TARGETS += xdp_stats
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
-# Extend with another COMMON_OBJS
-COMMON_OBJS += $(COMMON_DIR)/common_user_bpf_xdp.o
+COMMON_OBJS := $(COMMON_DIR)/common_user_bpf_xdp.o
 
 include $(COMMON_DIR)/common.mk

--- a/packet-solutions/Makefile
+++ b/packet-solutions/Makefile
@@ -5,11 +5,11 @@ XDP_TARGETS  += xdp_vlan01_kern
 XDP_TARGETS  += xdp_vlan02_kern
 USER_TARGETS := xdp_prog_user
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
 COPY_LOADER := xdp-loader
 COPY_STATS  := xdp_stats
-EXTRA_DEPS  += $(COMMON_DIR)/parsing_helpers.h
+EXTRA_DEPS  := $(COMMON_DIR)/parsing_helpers.h
 
-COMMON_OBJS += $(COMMON_DIR)/common_user_bpf_xdp.o
+COMMON_OBJS := $(COMMON_DIR)/common_user_bpf_xdp.o
 include $(COMMON_DIR)/common.mk

--- a/packet01-parsing/Makefile
+++ b/packet01-parsing/Makefile
@@ -3,7 +3,7 @@
 XDP_TARGETS  := xdp_prog_kern
 USER_TARGETS :=
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
 COPY_LOADER := xdp-loader
 COPY_STATS  := xdp_stats

--- a/packet02-rewriting/Makefile
+++ b/packet02-rewriting/Makefile
@@ -3,7 +3,7 @@
 XDP_TARGETS  := xdp_prog_kern
 USER_TARGETS :=
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
 COPY_LOADER := xdp-loader
 COPY_STATS  := xdp_stats

--- a/packet03-redirecting/Makefile
+++ b/packet03-redirecting/Makefile
@@ -3,7 +3,7 @@
 XDP_TARGETS  := xdp_prog_kern
 USER_TARGETS := xdp_prog_user
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
 COPY_LOADER := xdp-loader
 COPY_STATS  := xdp_stats

--- a/tracing01-xdp-simple/Makefile
+++ b/tracing01-xdp-simple/Makefile
@@ -4,7 +4,7 @@
 XDP_TARGETS  := trace_prog_kern xdp_prog_kern
 USER_TARGETS := trace_load_and_stats
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
 include $(COMMON_DIR)/common.mk
 

--- a/tracing02-xdp-monitor/Makefile
+++ b/tracing02-xdp-monitor/Makefile
@@ -4,10 +4,9 @@
 XDP_TARGETS  := trace_prog_kern
 USER_TARGETS := trace_load_and_stats
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
-# Extend with another COMMON_OBJS
-COMMON_OBJS += $(COMMON_DIR)/common_user_bpf_xdp.o
+COMMON_OBJS := $(COMMON_DIR)/common_user_bpf_xdp.o
 
 include $(COMMON_DIR)/common.mk
 

--- a/tracing03-xdp-debug-print/Makefile
+++ b/tracing03-xdp-debug-print/Makefile
@@ -3,13 +3,12 @@
 XDP_TARGETS := xdp_prog_kern
 USER_TARGETS := trace_read
 
-COPY_LOADER = xdp-loader
+COPY_LOADER := xdp-loader
 
 LLC ?= llc
 CLANG ?= clang
 CC := gcc
 
-COMMON_DIR = ../common
+COMMON_DIR := ../common
 
 include $(COMMON_DIR)/common.mk
-COMMON_OBJS := $(COMMON_DIR)/common_params.o

--- a/tracing04-xdp-tcpdump/Makefile
+++ b/tracing04-xdp-tcpdump/Makefile
@@ -7,4 +7,3 @@ LDLIBS+=-lpcap
 COMMON_DIR = ../common
 
 include $(COMMON_DIR)/common.mk
-COMMON_OBJS := $(COMMON_DIR)/common_params.o


### PR DESCRIPTION
This pull request makes the following improvements to the Makefiles:

- Prefer `:=` over `=`.
- Use `:=` instead of `+=` for initial assignments.
- Remove unnecessary assignments.
