### PR TITLE
tracing04 doc fixes

### DIFF
--- a/tracing04-xdp-tcpdump/README.org
+++ b/tracing04-xdp-tcpdump/README.org
@@ -24,14 +24,14 @@ to send events to the user space via perf event ring buffer:
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
 	__type(key, int);
-	__type(value, __u32);
+	__type(value, struct S);
 	__uint(max_entries, MAX_CPUS);
 } my_map SEC(".maps");
 #+end_example
 
-The value determines the size of the event data we will
+The value determines the type of the event data we will
 be posting to the user space through perf event ring buffer.
-In our case it's sizeof(u32) which is size of following structure:
+In our case it's struct S:
 
 #+begin_example sh
 struct S {

--- a/tracing04-xdp-tcpdump/README.org
+++ b/tracing04-xdp-tcpdump/README.org
@@ -29,9 +29,9 @@ struct {
 } my_map SEC(".maps");
 #+end_example
 
-The value determines the type of the event data we will
+The =value= determines the type of the event data we will
 be posting to the user space through perf event ring buffer.
-In our case it's struct S:
+In our case it's =struct S=:
 
 #+begin_example sh
 struct S {
@@ -40,8 +40,8 @@ struct S {
 } __packed;
 #+end_example
 
-We set the values of the event (metadata variable) and pass them
-into the bpf_perf_event_output call:
+We set the values of the event (=metadata= variable) and pass them
+into the =bpf_perf_event_output= call:
 
 #+begin_example sh
 int xdp_sample_prog(struct xdp_md *ctx)
@@ -64,8 +64,8 @@ int xdp_sample_prog(struct xdp_md *ctx)
 #+end_example
 
 To add the actual packet dump to the event, we can
-set flags upper 32 bits with the size of the requested sample
-and the bpf_perf_event_output will attach the specified
+set =flags= upper 32 bits with the size of the requested sample
+and the =bpf_perf_event_output= will attach the specified
 amount of bytes from packet to the perf event:
 
 
@@ -78,7 +78,7 @@ ret = bpf_perf_event_output(ctx, &my_map, flags,
                             &metadata, sizeof(metadata));
 #+end_example
 
-Please check the whole eBPF code in xdp_sample_pkts_kern.c file.
+Please check the whole eBPF code in =xdp_sample_pkts_kern.c= file.
 
 * Assignments
 

--- a/tracing04-xdp-tcpdump/README.org
+++ b/tracing04-xdp-tcpdump/README.org
@@ -29,7 +29,7 @@ struct {
 } my_map SEC(".maps");
 #+end_example
 
-The value_size determines the size of the event data we will
+The value determines the size of the event data we will
 be posting to the user space through perf event ring buffer.
 In our case it's sizeof(u32) which is size of following structure:
 

--- a/tracing04-xdp-tcpdump/xdp_sample_pkts_kern.c
+++ b/tracing04-xdp-tcpdump/xdp_sample_pkts_kern.c
@@ -20,7 +20,7 @@ struct S {
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
 	__type(key, int);
-	__type(value, __u32);
+	__type(value, struct S);
 	__uint(max_entries, MAX_CPUS);
 } my_map SEC(".maps");
 


### PR DESCRIPTION
Hello
This PR series has two commits for minor fixing on the documentation of tracing04

The first commit updates the variable name from `value_size` to `value`, as this was in the code to use the BTF format.

The second commit uses the verbatim mode for code discussion on the README (i.e. variable/function names). This is to match how verbatim is used in the previous lessons.