### PR TITLE
advanced03-AF_XDP: doc fixes

### DIFF
--- a/advanced03-AF_XDP/af_xdp_kern.c
+++ b/advanced03-AF_XDP/af_xdp_kern.c
@@ -21,23 +21,23 @@ struct {
 SEC("xdp")
 int xdp_sock_prog(struct xdp_md *ctx)
 {
-    int index = ctx->rx_queue_index;
-    __u32 *pkt_count;
+	int index = ctx->rx_queue_index;
+	__u32 *pkt_count;
 
-    pkt_count = bpf_map_lookup_elem(&xdp_stats_map, &index);
-    if (pkt_count) {
+	pkt_count = bpf_map_lookup_elem(&xdp_stats_map, &index);
+	if (pkt_count) {
 
-        /* We pass every other packet */
-        if ((*pkt_count)++ & 1)
-            return XDP_PASS;
-    }
+		/* We pass every other packet */
+		if ((*pkt_count)++ & 1)
+		return XDP_PASS;
+	}
 
-    /* A set entry here means that the correspnding queue_id
-     * has an active AF_XDP socket bound to it. */
-    if (bpf_map_lookup_elem(&xsks_map, &index))
-        return bpf_redirect_map(&xsks_map, index, 0);
+	/* A set entry here means that the correspnding queue_id
+	 * has an active AF_XDP socket bound to it. */
+	if (bpf_map_lookup_elem(&xsks_map, &index))
+		return bpf_redirect_map(&xsks_map, index, 0);
 
-    return XDP_PASS;
+	return XDP_PASS;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/advanced03-AF_XDP/af_xdp_user.c
+++ b/advanced03-AF_XDP/af_xdp_user.c
@@ -584,6 +584,14 @@ int main(int argc, char **argv)
 
 	/* Allow unlimited locking of memory, so all memory needed for packet
 	 * buffers can be locked.
+	 *
+	 * NOTE: since kernel v5.11, eBPF maps allocations are not tracked
+	 * through the process anymore. Now, eBPF maps are accounted to the
+	 * current cgroup of which the process that created the map is part of
+	 * (assuming the kernel was built with CONFIG_MEMCG).
+	 *
+	 * Therefore, you should ensure an appropriate memory.max setting on
+	 * the cgroup (via sysfs, for example) instead of relying on rlimit.
 	 */
 	if (setrlimit(RLIMIT_MEMLOCK, &rlim)) {
 		fprintf(stderr, "ERROR: setrlimit(RLIMIT_MEMLOCK) \"%s\"\n",

--- a/advanced03-AF_XDP/af_xdp_user.c
+++ b/advanced03-AF_XDP/af_xdp_user.c
@@ -281,7 +281,7 @@ static bool process_packet(struct xsk_socket_info *xsk,
 {
 	uint8_t *pkt = xsk_umem__get_data(xsk->umem->buffer, addr);
 
-    /* Lesson#3: Write an IPv6 ICMP ECHO parser to send responses
+	/* Lesson#3: Write an IPv6 ICMP ECHO parser to send responses
 	 *
 	 * Some assumptions to make it easier:
 	 * - No VLAN handling


### PR DESCRIPTION
Hello,
This is a PR with three commits

The first one is the only important one: pointing out that rlimit is not effective anymore for eBPF resource control.
I only added the commit, but did not remove the call to setrlimit(2).

The two others are style fixes -- no functional change intended.