### PR TITLE
Add m4 dependency under Ubuntu

### DIFF
--- a/setup_dependencies.org
+++ b/setup_dependencies.org
@@ -94,7 +94,7 @@ Note that you need to do this in the shell you are using to load programs
 On Debian and Ubuntu installations, install the dependencies like this:
 
 #+begin_example
-sudo apt install clang llvm libelf-dev libpcap-dev build-essential libc6-dev-i386
+sudo apt install clang llvm libelf-dev libpcap-dev build-essential libc6-dev-i386 m4
 #+end_example
 
 To install the 'perf' utility, run this on Debian:


### PR DESCRIPTION
Building of example code fails in Ubuntu 24.04 due to multiple issues:
- missing `m4` dependency.
- loop unrolling issue at `packet-solutions/xdp_vlan01_kern.c:66`