### PR TITLE
Reduce vlan recursion to 8

### DIFF
--- a/packet-solutions/xdp_vlan01_kern.c
+++ b/packet-solutions/xdp_vlan01_kern.c
@@ -6,7 +6,7 @@
 #include <bpf/bpf_endian.h>
 
 /* NOTICE: Re-defining VLAN header levels to parse */
-#define VLAN_MAX_DEPTH 10
+#define VLAN_MAX_DEPTH 8
 //#include "../common/parsing_helpers.h"
 /*
  * NOTICE: Copied over parts of ../common/parsing_helpers.h


### PR DESCRIPTION
Compiling with clang>1.17 fails with `error: loop not unrolled` if `VLAN_MAX_DEPTH>8`.