### PR TITLE
Fix typo and incorrect flags in tracing01-xdp-simple example command

### DIFF
--- a/tracing01-xdp-simple/README.org
+++ b/tracing01-xdp-simple/README.org
@@ -171,7 +171,7 @@ $ sudo ../testenv/testenv.sh setup --name veth-basic02
 Load the XDP program, that produces aborted packets:
 
 #+begin_src sh
-$ sudo xdp-loader load veth-basic02 xdp_prog_kern.o -n xdp_drop_func
+$ sudo xdp_loader load --dev veth-basic02 xdp_prog_kern.o --progname xdp_drop_func
 #+end_src
 
 and generate some packets:

--- a/tracing01-xdp-simple/README.org
+++ b/tracing01-xdp-simple/README.org
@@ -169,9 +169,11 @@ $ sudo ../testenv/testenv.sh setup --name veth-basic02
 #+end_src
 
 Load the XDP program, that produces aborted packets:
+(using =xdp-loader= from the
+[[https://github.com/xdp-project/xdp-tools][xdp-tools]] repository):
 
 #+begin_src sh
-$ sudo xdp_loader load --dev veth-basic02 xdp_prog_kern.o --progname xdp_drop_func
+$ sudo xdp-loader load veth-basic02 xdp_prog_kern.o -n xdp_drop_func
 #+end_src
 
 and generate some packets:


### PR DESCRIPTION

### Pull Request Description:

This PR fixes the example command in `tracing01-xdp-simple/README.org` which currently contains typos and incorrect command-line flags.

**Current (correct) command:**
```sh
sudo ./xdp_loader load --dev veth-basic02 xdp_prog_kern.o --progname xdp_drop_func
```

**Issues:**
1. Invalid flag: `-n` is not a valid option for `xdp_loader`. The correct flag is `--progname` .
2. The executable name and interface argument format are updated to match the standard `xdp_loader` usage (`xdp_loader load <ifname> <objfile>`).

**Before (incorrect) command:**
```sh
sudo xdp-loader load veth-basic02 xdp_prog_kern.o -n xdp_drop_func
```